### PR TITLE
Feat(server): 사용자 모델 jwt 인증 인프라 구현

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,47 @@
+"""애플리케이션 설정 관리"""
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing import List
+
+
+class Settings(BaseSettings):
+    """환경 변수 기반 설정"""
+
+    # Database (PostgreSQL)
+    DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/singchronize"
+
+    # JWT
+    SECRET_KEY: str = "your-secret-key-change-this-in-production"
+    ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
+
+    # CORS
+    ALLOWED_ORIGINS: str = "http://localhost:3000,http://localhost:5173"
+
+    # API Timeout (초)
+    OAUTH_API_TIMEOUT: int = 10
+
+    # OAuth Kakao
+    KAKAO_REST_API_KEY: str = ""
+    KAKAO_CLIENT_SECRET: str = ""
+    KAKAO_TOKEN_URL: str = "https://kauth.kakao.com/oauth/token"
+    KAKAO_USER_INFO_URL: str = "https://kapi.kakao.com/v2/user/me"
+
+    # OAuth Naver
+    NAVER_CLIENT_ID: str = ""
+    NAVER_CLIENT_SECRET: str = ""
+    NAVER_TOKEN_URL: str = "https://nid.naver.com/oauth2.0/token"
+    NAVER_USER_INFO_URL: str = "https://openapi.naver.com/v1/nid/me"
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=True,
+        extra="ignore",
+    )
+
+    @property
+    def allowed_origins_list(self) -> List[str]:
+        return [origin.strip() for origin in self.ALLOWED_ORIGINS.split(",")]
+
+
+settings = Settings()

--- a/backend/app/models/refresh_token.py
+++ b/backend/app/models/refresh_token.py
@@ -1,0 +1,26 @@
+"""RefreshToken 모델 (RTR 구현)"""
+import uuid
+from sqlalchemy import Column, String, DateTime, ForeignKey, Boolean
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class RefreshToken(Base):
+    __tablename__ = "refresh_tokens"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    token = Column(String, unique=True, nullable=False, index=True)
+    revoked = Column(Boolean, default=False, nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User", back_populates="refresh_tokens")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,41 @@
+"""User 모델 - PostgreSQL JSONB 활용"""
+import uuid
+from sqlalchemy import Column, String, DateTime, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    nickname = Column(String, nullable=False)
+    email = Column(String, unique=True, index=True, nullable=True)
+    profile_img = Column(String, nullable=True)
+
+    # Auth
+    provider = Column(String, nullable=False)       # kakao, naver
+    provider_id = Column(String, nullable=False)
+
+    # JSONB - 보컬 분석 캐시 (마이페이지 성능)
+    # 예: {"range": "C3~A5", "radar_chart": {"timbre": 80, "pitch": 90, ...}}
+    vocal_summary_cache = Column(JSONB, nullable=True)
+
+    # JSONB - 설정 통합 (별도 테이블 불필요)
+    # 예: {"push_enabled": true, "marketing_agree": false}
+    settings = Column(JSONB, default=lambda: {"push_enabled": True})
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    # Relationships
+    refresh_tokens = relationship(
+        "RefreshToken", back_populates="user", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        UniqueConstraint("provider", "provider_id", name="uq_provider_provider_id"),
+    )


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #11 


## 📤 Tasks
<!-- 해당 PR에 대한 작업 내용을 작성해주세요. -->
- SQLite에서 PostgreSQL(asyncpg)로 DB 연결 URL 변경
- JWT Secret 및 만료 시간 설정 추가
- Kakao/Naver OAuth 관련 설정값(Client ID/Secret) 추가
- Pydantic Settings 기반의 환경 변수 관리 구조 확립

- Users 테이블:
  - PostgreSQL JSONB 타입을 활용하여 `settings` 및 `vocal_summary_cache` 통합
  - 불필요한 서브 테이블(UserSettings, Preferences) 제거로 조회 성능 최적화
  - OAuth 제공자 정보(provider, provider_id) 컬럼 추가 및 유니크 제약 설정

- RefreshTokens 테이블:
  - RTR(Refresh Token Rotation) 구현을 위한 토큰 저장소 정의
  - User와 1:N 관계 설정 및 Cascade Delete 적용

