### PR TITLE
Feat(server): Oauth api (네이버, 카카오 로그인) 플로우 구현

### DIFF
--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,26 @@
+"""인증 관련 스키마"""
+from pydantic import BaseModel, Field
+from typing import Optional
+
+
+class SocialLoginRequest(BaseModel):
+    """POST /auth/login/{provider} 요청"""
+    access_token: str = Field(..., description="OAuth 제공자 액세스 토큰")
+    fcm_token: Optional[str] = Field(None, description="FCM 디바이스 토큰 (푸시알림)")
+
+
+class TokenResponse(BaseModel):
+    """토큰 응답 (공통)"""
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class LoginResponse(TokenResponse):
+    """POST /auth/login/{provider} 응답"""
+    is_new_user: bool
+
+
+class WithdrawRequest(BaseModel):
+    """POST /auth/withdraw 요청"""
+    reason: Optional[str] = Field(None, max_length=500, description="탈퇴 사유")

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,33 @@
+"""사용자 관련 스키마"""
+from pydantic import BaseModel, Field
+from typing import Optional, Dict, Any
+from datetime import datetime
+from uuid import UUID
+
+
+class UserResponse(BaseModel):
+    """GET /users/me 응답 - 보컬 캐시 포함"""
+    id: UUID
+    nickname: str
+    email: Optional[str] = None
+    profile_img: Optional[str] = None
+    provider: str
+    vocal_summary: Optional[Dict[str, Any]] = Field(
+        None, validation_alias="vocal_summary_cache"
+    )
+    settings: Dict[str, Any]
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+    model_config = {"from_attributes": True, "populate_by_name": True}
+
+
+class UserUpdateRequest(BaseModel):
+    """PATCH /users/me 요청"""
+    nickname: Optional[str] = Field(None, min_length=1, max_length=20)
+
+
+class SettingsUpdateRequest(BaseModel):
+    """PATCH /users/me/settings 요청 - JSONB 부분 업데이트"""
+    push_enabled: Optional[bool] = None
+    marketing_agree: Optional[bool] = None

--- a/backend/app/services/oauth/base.py
+++ b/backend/app/services/oauth/base.py
@@ -1,0 +1,47 @@
+"""OAuth 제공자 기본 인터페이스"""
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+
+class OAuthUserInfo:
+    """OAuth 사용자 정보 표준 포맷"""
+
+    def __init__(
+        self,
+        oauth_id: str,
+        email: str | None = None,
+        nickname: str | None = None,
+        profile_image_url: str | None = None,
+    ):
+        self.oauth_id = oauth_id
+        self.email = email
+        self.nickname = nickname
+        self.profile_image_url = profile_image_url
+
+
+class OAuthProvider(ABC):
+    """OAuth 제공자 추상 클래스"""
+
+    @abstractmethod
+    async def get_access_token(
+        self,
+        authorization_code: str,
+        redirect_uri: str
+    ) -> str:
+        """인가 코드로 액세스 토큰 획득"""
+        pass
+
+    @abstractmethod
+    async def get_user_info(self, access_token: str) -> OAuthUserInfo:
+        """액세스 토큰으로 사용자 정보 조회"""
+        pass
+
+    async def login(
+        self,
+        authorization_code: str,
+        redirect_uri: str
+    ) -> OAuthUserInfo:
+        """OAuth 로그인 플로우 (코드 → 토큰 → 사용자 정보)"""
+        access_token = await self.get_access_token(authorization_code, redirect_uri)
+        user_info = await self.get_user_info(access_token)
+        return user_info

--- a/backend/app/services/oauth/kakao.py
+++ b/backend/app/services/oauth/kakao.py
@@ -1,0 +1,191 @@
+"""카카오 OAuth 제공자 - 실제 API 호출 구현"""
+import httpx
+from typing import Dict, Any
+import logging
+
+from app.services.oauth.base import OAuthProvider, OAuthUserInfo
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class KakaoOAuthError(Exception):
+    """카카오 OAuth 관련 에러"""
+    def __init__(self, message: str, details: Dict[str, Any] | None = None):
+        self.message = message
+        self.details = details or {}
+        super().__init__(self.message)
+
+
+class KakaoOAuthProvider(OAuthProvider):
+    """
+    카카오 OAuth 2.0 구현
+
+    참고: https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api
+    """
+
+    async def get_access_token(
+        self,
+        authorization_code: str,
+        redirect_uri: str
+    ) -> str:
+        """
+        카카오 인가 코드로 액세스 토큰 획득
+
+        POST https://kauth.kakao.com/oauth/token
+        Content-Type: application/x-www-form-urlencoded;charset=utf-8
+
+        Args:
+            authorization_code: 카카오 인가 코드
+            redirect_uri: 리다이렉트 URI (프론트엔드에서 전달받은 값)
+
+        Returns:
+            카카오 액세스 토큰
+
+        Raises:
+            KakaoOAuthError: 토큰 발급 실패
+        """
+        if not settings.KAKAO_REST_API_KEY:
+            raise KakaoOAuthError(
+                "카카오 REST API 키가 설정되지 않았습니다.",
+                {"hint": "환경변수 KAKAO_REST_API_KEY를 설정해주세요."}
+            )
+
+        # 요청 데이터 구성
+        data = {
+            "grant_type": "authorization_code",
+            "client_id": settings.KAKAO_REST_API_KEY,
+            "redirect_uri": redirect_uri,
+            "code": authorization_code,
+        }
+
+        # Client Secret이 있으면 추가 (보안 강화 옵션)
+        if settings.KAKAO_CLIENT_SECRET:
+            data["client_secret"] = settings.KAKAO_CLIENT_SECRET
+
+        try:
+            async with httpx.AsyncClient(timeout=settings.OAUTH_API_TIMEOUT) as client:
+                response = await client.post(
+                    settings.KAKAO_TOKEN_URL,
+                    data=data,
+                    headers={
+                        "Content-Type": "application/x-www-form-urlencoded;charset=utf-8"
+                    }
+                )
+
+                # 카카오 API 에러 처리
+                if response.status_code != 200:
+                    error_data = response.json() if response.text else {}
+                    logger.error(f"카카오 토큰 발급 실패: {response.status_code} - {error_data}")
+                    raise KakaoOAuthError(
+                        "카카오 토큰 발급에 실패했습니다.",
+                        {
+                            "status_code": response.status_code,
+                            "error": error_data.get("error"),
+                            "error_description": error_data.get("error_description")
+                        }
+                    )
+
+                token_data = response.json()
+                access_token = token_data.get("access_token")
+
+                if not access_token:
+                    raise KakaoOAuthError(
+                        "카카오 응답에 access_token이 없습니다.",
+                        {"response": token_data}
+                    )
+
+                logger.info("카카오 액세스 토큰 발급 성공")
+                return access_token
+
+        except httpx.TimeoutException:
+            logger.error("카카오 토큰 API 타임아웃")
+            raise KakaoOAuthError(
+                "카카오 서버 응답 시간이 초과되었습니다.",
+                {"timeout": settings.OAUTH_API_TIMEOUT}
+            )
+        except httpx.RequestError as e:
+            logger.error(f"카카오 토큰 API 네트워크 오류: {str(e)}")
+            raise KakaoOAuthError(
+                "카카오 서버와의 통신에 실패했습니다.",
+                {"error": str(e)}
+            )
+
+    async def get_user_info(self, access_token: str) -> OAuthUserInfo:
+        """
+        카카오 액세스 토큰으로 사용자 정보 조회
+
+        GET/POST https://kapi.kakao.com/v2/user/me
+        Authorization: Bearer {access_token}
+
+        Args:
+            access_token: 카카오 액세스 토큰
+
+        Returns:
+            OAuthUserInfo: 표준화된 사용자 정보
+
+        Raises:
+            KakaoOAuthError: 사용자 정보 조회 실패
+        """
+        try:
+            async with httpx.AsyncClient(timeout=settings.OAUTH_API_TIMEOUT) as client:
+                response = await client.get(
+                    settings.KAKAO_USER_INFO_URL,
+                    headers={
+                        "Authorization": f"Bearer {access_token}",
+                        "Content-Type": "application/x-www-form-urlencoded;charset=utf-8"
+                    }
+                )
+
+                # 카카오 API 에러 처리
+                if response.status_code != 200:
+                    error_data = response.json() if response.text else {}
+                    logger.error(f"카카오 사용자 정보 조회 실패: {response.status_code} - {error_data}")
+                    raise KakaoOAuthError(
+                        "카카오 사용자 정보 조회에 실패했습니다.",
+                        {
+                            "status_code": response.status_code,
+                            "error": error_data.get("msg"),
+                            "code": error_data.get("code")
+                        }
+                    )
+
+                user_data = response.json()
+
+                # 필수 필드 추출
+                kakao_user_id = user_data.get("id")
+                if not kakao_user_id:
+                    raise KakaoOAuthError(
+                        "카카오 응답에 사용자 ID가 없습니다.",
+                        {"response": user_data}
+                    )
+
+                # 선택 필드 추출 (동의 항목에 따라 없을 수 있음)
+                kakao_account = user_data.get("kakao_account", {})
+                profile = kakao_account.get("profile", {})
+
+                email = kakao_account.get("email")
+                nickname = profile.get("nickname")
+                profile_image_url = profile.get("profile_image_url") or profile.get("thumbnail_image_url")
+
+                logger.info(f"카카오 사용자 정보 조회 성공: user_id={kakao_user_id}")
+
+                return OAuthUserInfo(
+                    oauth_id=str(kakao_user_id),
+                    email=email,
+                    nickname=nickname,
+                    profile_image_url=profile_image_url,
+                )
+
+        except httpx.TimeoutException:
+            logger.error("카카오 사용자 정보 API 타임아웃")
+            raise KakaoOAuthError(
+                "카카오 서버 응답 시간이 초과되었습니다.",
+                {"timeout": settings.OAUTH_API_TIMEOUT}
+            )
+        except httpx.RequestError as e:
+            logger.error(f"카카오 사용자 정보 API 네트워크 오류: {str(e)}")
+            raise KakaoOAuthError(
+                "카카오 서버와의 통신에 실패했습니다.",
+                {"error": str(e)}
+            )

--- a/backend/app/services/oauth/naver.py
+++ b/backend/app/services/oauth/naver.py
@@ -1,0 +1,207 @@
+"""네이버 OAuth 제공자 - 실제 API 호출 구현"""
+import httpx
+from typing import Dict, Any
+import logging
+
+from app.services.oauth.base import OAuthProvider, OAuthUserInfo
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class NaverOAuthError(Exception):
+    """네이버 OAuth 관련 에러"""
+    def __init__(self, message: str, details: Dict[str, Any] | None = None):
+        self.message = message
+        self.details = details or {}
+        super().__init__(self.message)
+
+
+class NaverOAuthProvider(OAuthProvider):
+    """
+    네이버 OAuth 2.0 구현
+
+    참고: https://developers.naver.com/docs/login/api/
+    """
+
+    async def get_access_token(
+        self,
+        authorization_code: str,
+        redirect_uri: str
+    ) -> str:
+        """
+        네이버 인가 코드로 액세스 토큰 획득
+
+        GET/POST https://nid.naver.com/oauth2.0/token
+
+        Args:
+            authorization_code: 네이버 인가 코드
+            redirect_uri: 리다이렉트 URI (프론트엔드에서 전달받은 값)
+
+        Returns:
+            네이버 액세스 토큰
+
+        Raises:
+            NaverOAuthError: 토큰 발급 실패
+        """
+        if not settings.NAVER_CLIENT_ID or not settings.NAVER_CLIENT_SECRET:
+            raise NaverOAuthError(
+                "네이버 Client ID 또는 Client Secret이 설정되지 않았습니다.",
+                {"hint": "환경변수 NAVER_CLIENT_ID, NAVER_CLIENT_SECRET을 설정해주세요."}
+            )
+
+        # 네이버는 state 파라미터가 필수이지만, 여기서는 간단히 "STATE" 사용
+        # 프로덕션에서는 CSRF 방지를 위해 랜덤 state 생성 및 검증 필요
+        params = {
+            "grant_type": "authorization_code",
+            "client_id": settings.NAVER_CLIENT_ID,
+            "client_secret": settings.NAVER_CLIENT_SECRET,
+            "code": authorization_code,
+            "state": "STATE",  # 프로덕션에서는 세션에 저장한 값과 비교
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=settings.OAUTH_API_TIMEOUT) as client:
+                # 네이버는 GET 또는 POST 모두 지원
+                response = await client.get(
+                    settings.NAVER_TOKEN_URL,
+                    params=params
+                )
+
+                # 네이버 API 에러 처리
+                if response.status_code != 200:
+                    error_data = response.json() if response.text else {}
+                    logger.error(f"네이버 토큰 발급 실패: {response.status_code} - {error_data}")
+                    raise NaverOAuthError(
+                        "네이버 토큰 발급에 실패했습니다.",
+                        {
+                            "status_code": response.status_code,
+                            "error": error_data.get("error"),
+                            "error_description": error_data.get("error_description")
+                        }
+                    )
+
+                token_data = response.json()
+
+                # 네이버는 에러가 있어도 200을 반환할 수 있음
+                if "error" in token_data:
+                    logger.error(f"네이버 토큰 발급 실패: {token_data}")
+                    raise NaverOAuthError(
+                        "네이버 토큰 발급에 실패했습니다.",
+                        {
+                            "error": token_data.get("error"),
+                            "error_description": token_data.get("error_description")
+                        }
+                    )
+
+                access_token = token_data.get("access_token")
+
+                if not access_token:
+                    raise NaverOAuthError(
+                        "네이버 응답에 access_token이 없습니다.",
+                        {"response": token_data}
+                    )
+
+                logger.info("네이버 액세스 토큰 발급 성공")
+                return access_token
+
+        except httpx.TimeoutException:
+            logger.error("네이버 토큰 API 타임아웃")
+            raise NaverOAuthError(
+                "네이버 서버 응답 시간이 초과되었습니다.",
+                {"timeout": settings.OAUTH_API_TIMEOUT}
+            )
+        except httpx.RequestError as e:
+            logger.error(f"네이버 토큰 API 네트워크 오류: {str(e)}")
+            raise NaverOAuthError(
+                "네이버 서버와의 통신에 실패했습니다.",
+                {"error": str(e)}
+            )
+
+    async def get_user_info(self, access_token: str) -> OAuthUserInfo:
+        """
+        네이버 액세스 토큰으로 사용자 정보 조회
+
+        GET https://openapi.naver.com/v1/nid/me
+        Authorization: Bearer {access_token}
+
+        Args:
+            access_token: 네이버 액세스 토큰
+
+        Returns:
+            OAuthUserInfo: 표준화된 사용자 정보
+
+        Raises:
+            NaverOAuthError: 사용자 정보 조회 실패
+        """
+        try:
+            async with httpx.AsyncClient(timeout=settings.OAUTH_API_TIMEOUT) as client:
+                response = await client.get(
+                    settings.NAVER_USER_INFO_URL,
+                    headers={
+                        "Authorization": f"Bearer {access_token}"
+                    }
+                )
+
+                # 네이버 API 에러 처리
+                if response.status_code != 200:
+                    error_data = response.json() if response.text else {}
+                    logger.error(f"네이버 사용자 정보 조회 실패: {response.status_code} - {error_data}")
+                    raise NaverOAuthError(
+                        "네이버 사용자 정보 조회에 실패했습니다.",
+                        {
+                            "status_code": response.status_code,
+                            "error": error_data.get("message")
+                        }
+                    )
+
+                user_data = response.json()
+
+                # 네이버 API 응답 구조: { "resultcode": "00", "message": "success", "response": {...} }
+                resultcode = user_data.get("resultcode")
+                if resultcode != "00":
+                    logger.error(f"네이버 사용자 정보 조회 실패: {user_data}")
+                    raise NaverOAuthError(
+                        "네이버 사용자 정보 조회에 실패했습니다.",
+                        {
+                            "resultcode": resultcode,
+                            "message": user_data.get("message")
+                        }
+                    )
+
+                response_data = user_data.get("response", {})
+
+                # 필수 필드 추출
+                naver_user_id = response_data.get("id")
+                if not naver_user_id:
+                    raise NaverOAuthError(
+                        "네이버 응답에 사용자 ID가 없습니다.",
+                        {"response": user_data}
+                    )
+
+                # 선택 필드 추출
+                email = response_data.get("email")
+                nickname = response_data.get("nickname") or response_data.get("name")
+                profile_image_url = response_data.get("profile_image")
+
+                logger.info(f"네이버 사용자 정보 조회 성공: user_id={naver_user_id}")
+
+                return OAuthUserInfo(
+                    oauth_id=str(naver_user_id),
+                    email=email,
+                    nickname=nickname,
+                    profile_image_url=profile_image_url,
+                )
+
+        except httpx.TimeoutException:
+            logger.error("네이버 사용자 정보 API 타임아웃")
+            raise NaverOAuthError(
+                "네이버 서버 응답 시간이 초과되었습니다.",
+                {"timeout": settings.OAUTH_API_TIMEOUT}
+            )
+        except httpx.RequestError as e:
+            logger.error(f"네이버 사용자 정보 API 네트워크 오류: {str(e)}")
+            raise NaverOAuthError(
+                "네이버 서버와의 통신에 실패했습니다.",
+                {"error": str(e)}
+            )


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #12 


## 📤 Tasks
<!-- 해당 PR에 대한 작업 내용을 작성해주세요. -->
- 로그인 플로우 변경: authorization_code + redirect_uri → access_token + fcm_token (프론트엔드가 코드 교환을 처리)
- vocal_summary: DB 컬럼명 vocal_summary_cache를 응답에서는 vocal_summary로 노출 (validation_alias)
- Settings 부분 업데이트: model_dump(exclude_unset=True) 활용하여 전달된 키만 JSONB 머지
<br/>

