### PR TITLE
Feat(server): Spotify API 연동 및 노래 검색 기능 구현

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,6 +34,10 @@ class Settings(BaseSettings):
     NAVER_TOKEN_URL: str = "https://nid.naver.com/oauth2.0/token"
     NAVER_USER_INFO_URL: str = "https://openapi.naver.com/v1/nid/me"
 
+    # Spotify
+    SPOTIFY_CLIENT_ID: str = ""
+    SPOTIFY_CLIENT_SECRET: str = ""
+    
     # 추가 설정 (필요시)
     SUPABASE_URL: str = "https://dzahkghhyoufwjhmbvkh.supabase.co"
     SUPABASE_SERVICE_ROLE_KEY: str = ""

--- a/backend/app/routers/songs.py
+++ b/backend/app/routers/songs.py
@@ -1,52 +1,22 @@
-from fastapi import APIRouter, Depends, Query, HTTPException
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, or_
-import logging  # 에러 추적을 위해 추가
+from fastapi import APIRouter, Depends
+from app.services.spotify import SpotifyService
+from app.config import settings # .env에 저장한 키 가져오기
 
-from app.database import get_db
-from app.models.song import Song
-from app.schemas.song import SongResponse
+router = APIRouter(prefix="/api/v1/music", tags=["music"])
 
-# 로거 설정
-logger = logging.getLogger(__name__)
+spotify = SpotifyService(settings.SPOTIFY_CLIENT_ID, settings.SPOTIFY_CLIENT_SECRET)
 
-router = APIRouter(prefix="/api/v1/songs", tags=["Songs"])
-
-@router.get("/search", response_model=SongResponse)
-async def search_songs(
-    q: str = Query(..., min_length=1, description="검색어 (제목 또는 가수)"),
-    db: AsyncSession = Depends(get_db),
-):
-    try:
-        # 1. 쿼리 생성
-        query = (
-            select(Song)
-            .where(
-                or_(
-                    Song.title.ilike(f"%{q}%"),
-                    Song.artist.ilike(f"%{q}%"),
-                )
-            )
-            .order_by(Song.created_at.desc())
-            .limit(20)
-        )
-
-        # 2. 실행 및 결과 페칭
-        result = await db.execute(query)
-        songs = result.scalars().all()
-        
-        # 3. 로그 찍기 (성공 확인용)
-        logger.info(f"🔍 검색어 '{q}' 검색 성공: {len(songs)}건 발견")
-
-        # 4. 결과 반환 (Response 모델 형식에 맞춤)
-        return SongResponse(songs=list(songs))
-
-    except Exception as e:
-        # 🚨 여기서 터미널에 진짜 에러 이유를 찍어줍니다!
-        logger.error(f"❌ 검색 중 에러 발생: {str(e)}")
-        
-        # 브라우저에서도 에러 내용을 확인할 수 있게 던져줍니다.
-        raise HTTPException(
-            status_code=500, 
-            detail=f"데이터베이스 연결 에러: {str(e)}"
-        )
+@router.get("/search")
+async def search_music(q: str):
+    results = spotify.search_tracks(q)
+    
+    # 필요한 정보(제목, 가수, 앨범커버, URI)만 추려서 프론트에 전달
+    tracks = []
+    for item in results.get("tracks", {}).get("items", []):
+        tracks.append({
+            "name": item["name"],
+            "artist": item["artists"][0]["name"],
+            "album_image": item["album"]["images"][0]["url"],
+            "uri": item["uri"] # 나중에 재생할 때 필수!
+        })
+    return tracks

--- a/backend/app/services/spotify.py
+++ b/backend/app/services/spotify.py
@@ -1,0 +1,56 @@
+import base64
+import requests
+
+class SpotifyService:
+    def __init__(self, client_id: str, client_secret: str):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.access_token = None
+
+    def get_token(self):
+        """스포티파이로부터 1시간짜리 Access Token을 받아옵니다."""
+        # Client ID와 Secret을 결합하여 Base64로 인코딩 (OAuth2 규격)
+        auth_str = f"{self.client_id}:{self.client_secret}"
+        auth_base64 = base64.b64encode(auth_str.encode()).decode()
+
+        url = "https://accounts.spotify.com/api/token"
+        headers = {
+            "Authorization": f"Basic {auth_base64}",
+            "Content-Type": "application/x-www-form-urlencoded"
+        }
+        data = {"grant_type": "client_credentials"}
+        
+        try:
+            response = requests.post(url, headers=headers, data=data)
+            response.raise_for_status() # 에러 발생 시 예외 처리
+            
+            self.access_token = response.json()["access_token"]
+            return self.access_token
+        except Exception as e:
+            print(f"❌ 토큰 발급 실패: {e}")
+            return None
+
+    def search_tracks(self, query: str):
+        """노래 제목으로 검색하여 결과를 반환합니다."""
+        # 토큰이 없으면 새로 받아오기
+        if not self.access_token:
+            self.get_token()
+
+        url = "https://api.spotify.com/v1/search"
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        # q: 검색어, type: 트랙(노래), limit: 10개, market: 한국 기준
+        params = {"q": query, "type": "track", "limit": 10, "market": "KR"}
+        
+        try:
+            response = requests.get(url, headers=headers, params=params)
+            
+            # 만약 토큰이 만료되어 401 에러가 나면 갱신 후 재시도
+            if response.status_code == 401:
+                self.get_token()
+                headers["Authorization"] = f"Bearer {self.access_token}"
+                response = requests.get(url, headers=headers, params=params)
+                
+            return response.json()
+        except Exception as e:
+            print(f"❌ 검색 실패: {e}")
+            return {"error": str(e)}


### PR DESCRIPTION
## 📌 Related Issue

- Closes #59 

## 📤 Tasks
- **Spotify API 인증 로직 구현**: `Client Credentials Flow`를 통해 Access Token을 발급받고, 만료 시(401 에러) 자동 갱신하는 로직 추가
- **환경 변수 관리**: Pydantic `Settings` 클래스에 `SPOTIFY_CLIENT_ID` 및 `SPOTIFY_CLIENT_SECRET` 속성 등록
- **노래 검색 엔드포인트 추가**: `GET /api/v1/music/search` 엔드포인트를 통해 노래 제목/가수 기반 검색 기능 구현
- **데이터 정제**: 스포티파이의 복잡한 응답 데이터에서 제목, 아티스트, 앨범 이미지, Spotify URI 정보만 추출하여 프론트엔드에 최적화된 형태로 반환

<br/>

## 📸 Screenshot

*(여기에 Swagger UI에서 검색 결과가 JSON으로 예쁘게 나오는 화면을 캡처해서 붙여주세요!)*
<img width="1416" height="159" alt="image" src="https://github.com/user-attachments/assets/e49327a8-a252-4c27-846a-8d6a1358b983" />
<img width="1408" height="806" alt="image" src="https://github.com/user-attachments/assets/e4c12df2-a533-4c81-8632-b74f855343af" />

<br/>

## 💌 To Reviewer
- **환경 변수 설정**: 로컬에서 테스트하실 때 `.env` 파일에 제가 공유해드린 Spotify ID와 Secret을 반드시 추가해야 정상 작동합니다.
- **예외 처리**: 토큰이 만료되어도 자동으로 재발급받아 검색을 재시도하도록 로직을 짰는데, 네트워크 지연 상황에서 어떻게 작동하는지 피드백 주시면 감사하겠습니다.
- **의존성**: `requests` 라이브러리가 추가되었으니 `pip install -r requirements.txt` 혹은 `pip install requests`를 꼭 확인해주세요!

<br/>