### PR TITLE
Fix(infra): GitHub Actions 의존성(requests) 누락 해결 및 API 문서 자동화 정상화

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,4 @@ pydantic-settings==2.7.0
 
 # OpenAPI export
 pyyaml==6.0.2
+requests


### PR DESCRIPTION
## 📌 Related Issue
- Closes #61 

## 📤 Tasks
- [x] `backend/requirements.txt`에 `requests` 라이브러리 추가
- [x] GitHub Actions 환경에서 백엔드 의존성 설치 후 스크립트 실행되도록 순서 보장

<br/>

## 📸 Screenshot
- ✅ `OpenAPI exported to .../contracts/openapi.yaml` 메시지 확인

<br/>

## 💌 To Reviewer
- `SpotifyService` 도입으로 인해 `requests` 라이브러리가 필수 의존성이 되었습니다. 
- 이번 수정을 통해 CI 환경에서 모듈 누락 에러 없이 OpenAPI 스펙 파일이 정상 생성되는 것을 확인했습니다.