### PR TITLE
Feat(client): 노래방 키트 페이지 보컬 기록 UI 구현

### DIFF
--- a/frontend/apps/client/src/app/(main)/layout.tsx
+++ b/frontend/apps/client/src/app/(main)/layout.tsx
@@ -1,7 +1,13 @@
+import { Sidebar } from '@/shared/components';
+
 const MainLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div>
-      <main>{children}</main>
+    <div className='flex h-full overflow-hidden'>
+      <aside className='shrink-0'>
+        <Sidebar />
+      </aside>
+
+      <main className='flex-1 overflow-y-auto'>{children}</main>
     </div>
   );
 };

--- a/frontend/apps/client/src/app/(main)/library/page.tsx
+++ b/frontend/apps/client/src/app/(main)/library/page.tsx
@@ -1,7 +1,25 @@
+'use client';
+
+import { SectionTab } from '@/shared/components';
+import { useSectionTab } from '@/shared/hooks';
+import { LibraryBanner, LibraryHistoryList } from '@/widgets/library/ui';
+
 const LibraryPage = () => {
+  const { tab, tabs, changeTab } = useSectionTab({
+    items: [
+      { key: 'wishlist', label: '찜 리스트' },
+      { key: 'history', label: '보컬 기록' },
+    ] as const,
+    initialTab: 'wishlist',
+  });
+
   return (
-    <div>
-      <h1>Library</h1>
+    <div className='flex-1 min-h-screen'>
+      <LibraryBanner />
+      <div className='px-8'>
+        <SectionTab items={tabs} value={tab} onChange={(nextTab) => changeTab(nextTab)} />
+        {tab == 'wishlist' ? <></> : <LibraryHistoryList />}
+      </div>
     </div>
   );
 };

--- a/frontend/apps/client/src/app/layout.tsx
+++ b/frontend/apps/client/src/app/layout.tsx
@@ -2,20 +2,14 @@ import type { Metadata } from 'next';
 import { metadataConfig } from './metadata';
 import './global.css';
 import { TooltipProvider } from '@singchronize/ui';
-import { Sidebar } from '@/shared/components';
 
 export const metadata: Metadata = metadataConfig;
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang='ko'>
-      <body>
-        <TooltipProvider delayDuration={0}>
-          <div className='flex min-h-screen'>
-            <Sidebar />
-            <main className='flex-1 bg-bg'>{children}</main>
-          </div>
-        </TooltipProvider>
+      <body className='h-screen overflow-hidden bg-bg'>
+        <TooltipProvider delayDuration={0}>{children}</TooltipProvider>
       </body>
     </html>
   );

--- a/frontend/apps/client/src/entities/library/model/mapper.ts
+++ b/frontend/apps/client/src/entities/library/model/mapper.ts
@@ -1,0 +1,12 @@
+import { isHistoryTag } from './tags';
+import { HistoryItemApiType, HistoryItemUiType } from './types';
+
+export const toHistoryItemUi = (item: HistoryItemApiType): HistoryItemUiType => ({
+  historyId: item.history_id,
+  title: item.song.title,
+  artist: item.song.artist ?? '',
+  thumbnail: item.song.album_cover ?? undefined,
+  tags: (item.tags ?? []).filter(isHistoryTag),
+  memo: item.memo ?? undefined,
+  date: item.date,
+});

--- a/frontend/apps/client/src/entities/library/model/mock.ts
+++ b/frontend/apps/client/src/entities/library/model/mock.ts
@@ -1,0 +1,44 @@
+import type { HistoryItemApiType } from './types';
+import { toHistoryItemUi } from './mapper';
+
+const MOCK_HISTORY_ITEMS_API: HistoryItemApiType[] = [
+  {
+    history_id: 'h1',
+    song: {
+      id: 's1',
+      title:
+        '전체적으로 리듬은 잘 맞았고 초반 흐름도 안정적이었음. 다만 후반부로 갈수록 호흡이 부족해지면서 음정',
+      artist: '박효신',
+      album_cover: '',
+    },
+    tags: ['AGAIN', 'PRACTICE'],
+    memo: '전체적으로 리듬은 잘 맞았고 초반 흐름도 안정적이었음. 다만 후반부로 갈수록 호흡이 부족해지면서 음정이 점점 흔들렸음. 특히 고음 구간에서 목에 힘이 들어가 소리가 얇아지고 답답하게 들렸음. 녹음으로 다시 들어보니 발음이 뭉개지는 부분도 있었고, 감정 표현이 일정하지 않았음. 다음에는 호흡을 더 길게 가져가고 고음 파트를 따로 나눠 연습할 필요가 있음. 전체적으로 힘을 빼고 부르는 연습도 같이 해보면 좋을 것 같음.',
+    date: '2026.02.15',
+  },
+  {
+    history_id: 'h2',
+    song: {
+      id: 's2',
+      title: '밤편지',
+      artist: '아이유',
+      album_cover: '',
+    },
+    tags: ['COMFORTABLE'],
+    memo: null,
+    date: '2026.02.10',
+  },
+  {
+    history_id: 'h3',
+    song: {
+      id: 's3',
+      title: '사건의 지평선',
+      artist: '윤하',
+      album_cover: '',
+    },
+    tags: ['BAD_CONDITION', 'NOT_MY_STYLE'],
+    memo: '키가 높아서 힘들었음',
+    date: '2026.02.03',
+  },
+];
+
+export const MOCK_HISTORY_ITEMS = MOCK_HISTORY_ITEMS_API.map(toHistoryItemUi);

--- a/frontend/apps/client/src/entities/library/model/tags.ts
+++ b/frontend/apps/client/src/entities/library/model/tags.ts
@@ -1,0 +1,35 @@
+export type HistoryTagType =
+  | 'AGAIN'
+  | 'COMFORTABLE'
+  | 'PRACTICE'
+  | 'BAD_CONDITION'
+  | 'NOT_MY_STYLE';
+
+export type HistoryTagKeyType = 'all' | HistoryTagType;
+
+type TagOption = {
+  key: HistoryTagKeyType;
+  label: string;
+};
+
+export const HISTORY_TAG_OPTIONS: readonly TagOption[] = [
+  { key: 'all', label: '전체' },
+  { key: 'AGAIN', label: '다음에 또 부를래요' },
+  { key: 'COMFORTABLE', label: '부르기 편했어요' },
+  { key: 'PRACTICE', label: '연습하고 싶어요' },
+  { key: 'BAD_CONDITION', label: '오늘은 안 맞았어요' },
+  { key: 'NOT_MY_STYLE', label: '별로예요' },
+];
+
+export const getHistoryTagLabel = (key: HistoryTagKeyType): string => {
+  const found = HISTORY_TAG_OPTIONS.find((o) => o.key === key);
+  return found ? found.label : key;
+};
+
+// 런타임 가드
+const TAG_SET = new Set<HistoryTagType>(
+  HISTORY_TAG_OPTIONS.map((o) => o.key).filter((k): k is HistoryTagType => k !== 'all')
+);
+
+export const isHistoryTag = (value: string): value is HistoryTagType =>
+  TAG_SET.has(value as HistoryTagType);

--- a/frontend/apps/client/src/entities/library/model/tags.ts
+++ b/frontend/apps/client/src/entities/library/model/tags.ts
@@ -12,7 +12,7 @@ type TagOption = {
   label: string;
 };
 
-export const HISTORY_TAG_OPTIONS: readonly TagOption[] = [
+export const HISTORY_FILTER_OPTIONS: readonly TagOption[] = [
   { key: 'all', label: '전체' },
   { key: 'AGAIN', label: '다음에 또 부를래요' },
   { key: 'COMFORTABLE', label: '부르기 편했어요' },
@@ -21,14 +21,18 @@ export const HISTORY_TAG_OPTIONS: readonly TagOption[] = [
   { key: 'NOT_MY_STYLE', label: '별로예요' },
 ];
 
+export const HISTORY_TAG_OPTIONS = HISTORY_FILTER_OPTIONS.filter(
+  (opt): opt is { key: HistoryTagType; label: string } => opt.key !== 'all'
+);
+
 export const getHistoryTagLabel = (key: HistoryTagKeyType): string => {
-  const found = HISTORY_TAG_OPTIONS.find((o) => o.key === key);
+  const found = HISTORY_FILTER_OPTIONS.find((o) => o.key === key);
   return found ? found.label : key;
 };
 
 // 런타임 가드
 const TAG_SET = new Set<HistoryTagType>(
-  HISTORY_TAG_OPTIONS.map((o) => o.key).filter((k): k is HistoryTagType => k !== 'all')
+  HISTORY_FILTER_OPTIONS.map((o) => o.key).filter((k): k is HistoryTagType => k !== 'all')
 );
 
 export const isHistoryTag = (value: string): value is HistoryTagType =>

--- a/frontend/apps/client/src/entities/library/model/types.ts
+++ b/frontend/apps/client/src/entities/library/model/types.ts
@@ -1,0 +1,20 @@
+import type { SongApiType } from '@/entities/song/model/types';
+import { HistoryTagType } from './tags';
+
+export type HistoryItemApiType = {
+  history_id: string;
+  song: SongApiType;
+  tags: string[];
+  memo?: string | null;
+  date: string; // "2026.02.15"
+};
+
+export type HistoryItemUiType = {
+  historyId: string;
+  title: string;
+  artist: string;
+  thumbnail?: string;
+  tags: HistoryTagType[];
+  memo?: string;
+  date: string;
+};

--- a/frontend/apps/client/src/entities/library/ui/HistoryItem.tsx
+++ b/frontend/apps/client/src/entities/library/ui/HistoryItem.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { cn } from '@/shared/lib/cn';
+import type { HistoryItemUiType } from '../model/types';
+import { getHistoryTagLabel } from '../model/tags';
+
+type HistoryItemProps = {
+  item: HistoryItemUiType;
+  onEditClick?: (historyId: string) => void;
+};
+
+const HistoryItem = ({ item, onEditClick }: HistoryItemProps) => {
+  const hasTags = (item.tags?.length ?? 0) > 0;
+  const hasMemo = Boolean(item.memo && item.memo.trim().length > 0);
+
+  return (
+    <article
+      className={cn(
+        'px-10 py-7 flex gap-6 bg-gray-900 border-2 border-gray-800 rounded-10'
+      )}
+    >
+      <div className='relative size-23 shrink-0 overflow-hidden rounded-10'>
+        {item.thumbnail ? (
+          <img src={item.thumbnail} alt={item.title} className='size-full object-cover' />
+        ) : (
+          <div className='size-full bg-white-10' />
+        )}
+      </div>
+
+      <div className='flex flex-1 flex-col gap-4 min-w-0'>
+        {/* 음원 정보 */}
+        <div className='flex items-center justify-between gap-6'>
+          <div className='flex flex-1 flex-col min-w-0'>
+            <h3 className='typo-24b text-white truncate'>{item.title}</h3>
+            <p className='mt-0.5 typo-16r text-gray-200 truncate'>{item.artist}</p>
+            <p className='mt-2 typo-16r text-gray-400'>{item.date}</p>
+          </div>
+
+          <button
+            type='button'
+            onClick={() => onEditClick?.(item.historyId)}
+            className={cn('typo-16m text-gray-200 shrink-0')}
+          >
+            수정하기
+          </button>
+        </div>
+
+        {/* 태그 */}
+        {hasTags && (
+          <div className='flex flex-col gap-2'>
+            <h4 className='typo-18sb text-gray-200'>평가</h4>
+            <div className='flex gap-2'>
+              {item.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className={cn(
+                    'px-5 py-2 bg-gray-800 rounded-full',
+                    'typo-16m text-gray-100'
+                  )}
+                >
+                  {getHistoryTagLabel(tag)}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 메모 */}
+        {hasMemo && (
+          <div className='flex flex-col gap-2'>
+            <h4 className='typo-18sb text-gray-200'>메모</h4>
+            <div className='px-6 py-4 bg-gray-800 rounded-10'>
+              <p className='typo-16r text-gray-100 whitespace-pre-wrap'>{item.memo}</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+};
+
+export default HistoryItem;

--- a/frontend/apps/client/src/entities/library/ui/index.ts
+++ b/frontend/apps/client/src/entities/library/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as HistoryItem } from './HistoryItem';

--- a/frontend/apps/client/src/entities/song/model/mock.ts
+++ b/frontend/apps/client/src/entities/song/model/mock.ts
@@ -1,7 +1,10 @@
-import type { SongApiType } from './types';
+import type { SongApiType, SongUiType } from './types';
+import { toSongUi } from './mapper';
 
 export const MOCK_SONGS: SongApiType[] = [
-  { id: '1', title: 'Song A', artist: 'Artist A' },
-  { id: '2', title: 'Song B', artist: 'Artist B' },
-  { id: '3', title: 'Song C', artist: 'Artist C' },
+  { id: '1', title: '밤편지', artist: '아이유', album_cover: null },
+  { id: '2', title: 'The Action', artist: 'BOYNEXTDOOR', album_cover: null },
+  { id: '3', title: 'Celebrity', artist: '아이유', album_cover: null },
 ];
+
+export const MOCK_SONG_LIST: SongUiType[] = MOCK_SONGS.map(toSongUi);

--- a/frontend/apps/client/src/entities/song/ui/SongListItem.tsx
+++ b/frontend/apps/client/src/entities/song/ui/SongListItem.tsx
@@ -88,7 +88,7 @@ const SongListItem = ({
       </div>
 
       {/* [중앙] 곡 정보 */}
-      <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+      <div className='flex min-w-0 flex-1 flex-col gap-0.5 text-left'>
         <h4 className='truncate typo-18sb text-white'>{title}</h4>
         <p className='truncate typo-14r text-gray-200'>{artist}</p>
       </div>

--- a/frontend/apps/client/src/entities/song/ui/SongListItem.tsx
+++ b/frontend/apps/client/src/entities/song/ui/SongListItem.tsx
@@ -24,6 +24,9 @@ interface SongListItemProps {
   // list4
   likeCount?: number;
 
+  // list3
+  rightSlot?: React.ReactNode;
+
   // ui state
   isLiked?: boolean;
 
@@ -43,6 +46,7 @@ const SongListItem = ({
   musicKey,
   matchRate,
   likeCount,
+  rightSlot,
   isLiked = false,
   onLikeClick,
   onMoreClick,
@@ -131,12 +135,16 @@ const SongListItem = ({
       {/* [오른쪽] 액션 영역 */}
       <div className='flex items-center'>
         {/* list3: 하트 + 더보기 */}
-        {variant === 'list3' && (
-          <div className='flex items-center gap-1.25'>
-            <LikeIconButton isLiked={isLiked} onClick={handleLikeClick} />
-            <MoreActionButton onClick={handleMoreClick} />
-          </div>
-        )}
+        {variant === 'list3' ? (
+          rightSlot ? (
+            <div className='flex items-center'>{rightSlot}</div>
+          ) : (
+            <div className='flex items-center gap-1.25'>
+              <LikeIconButton isLiked={isLiked} onClick={handleLikeClick} />
+              <MoreActionButton onClick={handleMoreClick} />
+            </div>
+          )
+        ) : null}
 
         {/* list2, list5: 하트 */}
         {(variant === 'list2' || variant === 'list5') && (

--- a/frontend/apps/client/src/features/add-history/ui/AddHistoryModal.tsx
+++ b/frontend/apps/client/src/features/add-history/ui/AddHistoryModal.tsx
@@ -6,6 +6,9 @@ import { InputField, Button, TextAreaField } from '@singchronize/ui';
 import { SongListItem } from '@/entities/song/ui';
 import { IcBack, IcPlus } from '@/shared/assets/icons';
 import { HISTORY_TAG_OPTIONS, HistoryTagKeyType } from '@/entities/library/model/tags';
+import type { SongUiType } from '@/entities/song/model/types';
+
+import { MOCK_SONG_LIST } from '@/entities/song/model/mock';
 
 type AddHistoryModalProps = {
   onClose: () => void;
@@ -13,17 +16,10 @@ type AddHistoryModalProps = {
 
 type Step = 'search' | 'form';
 
-type SelectedSong = {
-  id: string | number;
-  title: string;
-  artist: string;
-  thumbnail?: string;
-};
-
 const AddHistoryModal = ({ onClose }: AddHistoryModalProps) => {
   const [step, setStep] = useState<Step>('search');
   const [query, setQuery] = useState('');
-  const [selectedSong, setSelectedSong] = useState<SelectedSong | null>(null);
+  const [selectedSong, setSelectedSong] = useState<SongUiType | null>(null);
 
   const [memo, setMemo] = useState('');
   const [selectedTags, setSelectedTags] = useState<Set<HistoryTagKeyType>>(
@@ -39,16 +35,18 @@ const AddHistoryModal = ({ onClose }: AddHistoryModalProps) => {
     });
   };
 
-  // TODO: 검색 결과/아카이브를 API로 교체
-  const archiveItems = useMemo<SelectedSong[]>(
-    () => [
-      { id: 1, title: '밤편지', artist: '아이유', thumbnail: '' },
-      { id: 2, title: 'The Action', artist: 'BOYNEXTDOOR', thumbnail: '' },
-    ],
-    []
-  );
+  // TODO: 검색 결과를 API로 교체
+  const searchedItems = useMemo(() => {
+    const q = query.trim();
+    if (!q) return [];
 
-  const handleSelectSong = (song: SelectedSong) => {
+    return MOCK_SONG_LIST.filter((song) => {
+      const hay = `${song.title} ${song.artist}`;
+      return hay.includes(q);
+    });
+  }, [query]);
+
+  const handleSelectSong = (song: SongUiType) => {
     setSelectedSong(song);
     setStep('form');
   };
@@ -75,31 +73,22 @@ const AddHistoryModal = ({ onClose }: AddHistoryModalProps) => {
             />
           </div>
 
-          <div className='flex flex-col gap-3 min-h-0'>
-            <p className='typo-20b text-white'>아카이브</p>
-
-            <div className='flex flex-col gap-4 overflow-y-auto min-h-0'>
-              {archiveItems.map((song) => (
-                <button
-                  key={song.id}
-                  type='button'
-                  className='text-left'
-                  onClick={() => handleSelectSong(song)}
-                >
-                  <SongListItem
-                    variant='list3'
-                    title={song.title}
-                    artist={song.artist}
-                    thumbnail={song.thumbnail ?? ''}
-                    rightSlot={
-                      <span className='inline-flex items-center justify-center'>
-                        <IcPlus />
-                      </span>
-                    }
-                  />
-                </button>
-              ))}
-            </div>
+          <div className='flex flex-col gap-4 overflow-y-auto min-h-0'>
+            {searchedItems.map((song) => (
+              <button key={song.id} type='button' onClick={() => handleSelectSong(song)}>
+                <SongListItem
+                  variant='list3'
+                  title={song.title}
+                  artist={song.artist}
+                  thumbnail={song.thumbnail ?? ''}
+                  rightSlot={
+                    <span className='inline-flex items-center justify-center'>
+                      <IcPlus />
+                    </span>
+                  }
+                />
+              </button>
+            ))}
           </div>
         </div>
       ) : (

--- a/frontend/apps/client/src/features/add-history/ui/AddHistoryModal.tsx
+++ b/frontend/apps/client/src/features/add-history/ui/AddHistoryModal.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { BaseModal, SelectChip } from '@/shared/components';
+import { InputField, Button, TextAreaField } from '@singchronize/ui';
+import { SongListItem } from '@/entities/song/ui';
+import { IcBack, IcPlus } from '@/shared/assets/icons';
+import { HISTORY_TAG_OPTIONS, HistoryTagKeyType } from '@/entities/library/model/tags';
+
+type AddHistoryModalProps = {
+  onClose: () => void;
+};
+
+type Step = 'search' | 'form';
+
+type SelectedSong = {
+  id: string | number;
+  title: string;
+  artist: string;
+  thumbnail?: string;
+};
+
+const AddHistoryModal = ({ onClose }: AddHistoryModalProps) => {
+  const [step, setStep] = useState<Step>('search');
+  const [query, setQuery] = useState('');
+  const [selectedSong, setSelectedSong] = useState<SelectedSong | null>(null);
+
+  const [memo, setMemo] = useState('');
+  const [selectedTags, setSelectedTags] = useState<Set<HistoryTagKeyType>>(
+    () => new Set()
+  );
+
+  const toggleTag = (key: HistoryTagKeyType) => {
+    setSelectedTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  // TODO: 검색 결과/아카이브를 API로 교체
+  const archiveItems = useMemo<SelectedSong[]>(
+    () => [
+      { id: 1, title: '밤편지', artist: '아이유', thumbnail: '' },
+      { id: 2, title: 'The Action', artist: 'BOYNEXTDOOR', thumbnail: '' },
+    ],
+    []
+  );
+
+  const handleSelectSong = (song: SelectedSong) => {
+    setSelectedSong(song);
+    setStep('form');
+  };
+
+  const handleBackToSearch = () => {
+    setStep('search');
+    setSelectedSong(null);
+    setSelectedTags(new Set());
+  };
+
+  return (
+    <BaseModal
+      onClose={onClose}
+      className='relative px-25 flex flex-col w-full max-w-226 max-h-178 h-[70vh] bg-bg rounded-20'
+    >
+      {step === 'search' ? (
+        <div className='pt-14.5 flex flex-col gap-7 h-full'>
+          <div className='flex flex-col gap-7'>
+            <h2 className='typo-32b text-white'>보컬기록 추가하기</h2>
+            <InputField
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder='노래 제목이나 가수를 입력해주세요'
+            />
+          </div>
+
+          <div className='flex flex-col gap-3 min-h-0'>
+            <p className='typo-20b text-white'>아카이브</p>
+
+            <div className='flex flex-col gap-4 overflow-y-auto min-h-0'>
+              {archiveItems.map((song) => (
+                <button
+                  key={song.id}
+                  type='button'
+                  className='text-left'
+                  onClick={() => handleSelectSong(song)}
+                >
+                  <SongListItem
+                    variant='list3'
+                    title={song.title}
+                    artist={song.artist}
+                    thumbnail={song.thumbnail ?? ''}
+                    rightSlot={
+                      <span className='inline-flex items-center justify-center'>
+                        <IcPlus />
+                      </span>
+                    }
+                  />
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className='pt-21 flex flex-col h-full'>
+          <button
+            type='button'
+            className='absolute top-10 left-10'
+            onClick={handleBackToSearch}
+          >
+            <IcBack />
+          </button>
+
+          <div className='flex flex-1 flex-col gap-7 overflow-y-scroll scrollbar-hide'>
+            <div className='flex flex-col gap-3'>
+              <h2 className='typo-24b text-gray-100'>선택한 노래</h2>
+              {selectedSong ? (
+                <SongListItem
+                  variant='list3'
+                  title={selectedSong.title}
+                  artist={selectedSong.artist}
+                  thumbnail={selectedSong.thumbnail ?? ''}
+                  rightSlot={<></>}
+                />
+              ) : null}
+            </div>
+
+            <div className='flex flex-col gap-3'>
+              <div>
+                <h2 className='typo-24b text-gray-200'>평가하기</h2>
+                <p className='typo-14r text-gray-500'>여러 개 선택할 수 있어요!</p>
+              </div>
+
+              <div className='flex flex-wrap items-center gap-x-2 gap-y-3 w-105'>
+                {HISTORY_TAG_OPTIONS.map((opt) => (
+                  <SelectChip
+                    key={opt.key}
+                    label={opt.label}
+                    selected={selectedTags.has(opt.key)}
+                    onClick={() => toggleTag(opt.key)}
+                  />
+                ))}
+              </div>
+            </div>
+
+            <div className='flex flex-col gap-3'>
+              <div className='flex gap-1'>
+                <h2 className='typo-24b text-gray-200'>메모하기</h2>
+                <h2 className='typo-24b text-gray-400'>(선택)</h2>
+              </div>
+              <TextAreaField
+                value={memo}
+                onChange={(e) => setMemo(e.target.value)}
+                placeholder='부르면서 느낀 점을 적어보세요'
+              />
+            </div>
+          </div>
+
+          <div className='py-7 mx-auto'>
+            <Button
+              variant='normal'
+              onClick={() => {
+                // TODO: 저장 API 연결
+                onClose();
+              }}
+              disabled={!selectedSong || selectedTags.size === 0}
+            >
+              저장하기
+            </Button>
+          </div>
+        </div>
+      )}
+    </BaseModal>
+  );
+};
+
+export default AddHistoryModal;

--- a/frontend/apps/client/src/features/add-history/ui/index.ts
+++ b/frontend/apps/client/src/features/add-history/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as AddHistoryModal } from './AddHistoryModal';

--- a/frontend/apps/client/src/features/ranking/ui/StepRanking.tsx
+++ b/frontend/apps/client/src/features/ranking/ui/StepRanking.tsx
@@ -1,12 +1,11 @@
 import { Button } from '@singchronize/ui';
 import SortableSongList from './SortableSongList';
-import { toSongUi } from '@/entities/song/model/mapper';
 
-import { MOCK_SONGS } from '@/entities/song/model/mock';
+import { MOCK_SONG_LIST } from '@/entities/song/model/mock';
 
 const StepRanking = ({ onNext }: { onNext: () => void }) => {
   // TODO: 쿼리 훅으로 교체
-  const songs = MOCK_SONGS.map(toSongUi);
+  const songs = MOCK_SONG_LIST;
 
   return (
     <div className='mt-[4vh] mb-[8vh] flex flex-col justify-center h-full'>

--- a/frontend/apps/client/src/features/record/ui/MicTestModal.tsx
+++ b/frontend/apps/client/src/features/record/ui/MicTestModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { IcClose } from '@/shared/assets/icons';
+import { BaseModal } from '@/shared/components';
 import MicTestStep from './MicTestStep';
 import StartAnalysisStep from './StartAnalysisStep';
 
@@ -17,37 +17,32 @@ const MicTestModal = ({ gain, onChangeGain, onClose }: MicTestModalProps) => {
   const [step, setStep] = useState<Step>('mic-test');
 
   return (
-    <div className='fixed inset-0 z-50 flex items-center justify-center bg-dim'>
-      <div
-        className='
-        relative w-full max-w-226 h-178 rounded-20
-        px-16.5 py-19.5 flex flex-col items-center justify-center
-        bg-bg bg-[radial-gradient(50%_50%_at_50%_50%,rgba(200,255,0,0.17)_0%,rgba(22,22,22,0.17)_100%)]
-        bg-size-[130%_200%]
-        bg-position-[50%_-10%]
-        '
-      >
-        {step === 'mic-test' && (
-          <MicTestStep
-            gain={gain}
-            onChangeGain={onChangeGain}
-            onFinish={() => setStep('start-analysis')}
-          />
-        )}
+    <BaseModal
+      onClose={onClose}
+      className='
+      relative w-full max-w-226 max-h-178 h-[80vh] rounded-20
+      px-16.5 py-19.5 flex flex-col items-center justify-center
+      bg-bg bg-[radial-gradient(50%_50%_at_50%_50%,rgba(200,255,0,0.17)_0%,rgba(22,22,22,0.17)_100%)]
+      bg-size-[130%_200%]
+      bg-position-[50%_-10%]
+      '
+    >
+      {step === 'mic-test' && (
+        <MicTestStep
+          gain={gain}
+          onChangeGain={onChangeGain}
+          onFinish={() => setStep('start-analysis')}
+        />
+      )}
 
-        {step === 'start-analysis' && (
-          <StartAnalysisStep
-            onStart={() => {
-              onClose();
-            }}
-          />
-        )}
-
-        <button className='absolute bottom-[-64]' onClick={onClose}>
-          <IcClose />
-        </button>
-      </div>
-    </div>
+      {step === 'start-analysis' && (
+        <StartAnalysisStep
+          onStart={() => {
+            onClose();
+          }}
+        />
+      )}
+    </BaseModal>
   );
 };
 

--- a/frontend/apps/client/src/features/record/ui/StepRecord.tsx
+++ b/frontend/apps/client/src/features/record/ui/StepRecord.tsx
@@ -9,7 +9,7 @@ import { useRecorder, useTimer } from '../model';
 import { GUIDE_TEXT_BY_LEVEL } from '../model/constants';
 
 const StepRecord = ({ onNext }: { onNext: () => void }) => {
-  const { open: isMicTestOpen, setOpen: setIsMicTestOpen, closeModal } = useModal(true);
+  const { open: isMicTestOpen, closeModal } = useModal(true);
   const [micGain, setMicGain] = useState(1);
 
   const { phase, start, pause, finish, handleRecorded } = useRecorder();

--- a/frontend/apps/client/src/features/record/ui/StepRecord.tsx
+++ b/frontend/apps/client/src/features/record/ui/StepRecord.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useModal } from '@/shared/hooks';
 import RecordingControls from './RecordingControls';
 import WaveformRecorder from './WaveformRecorder';
 import MicTestModal from './MicTestModal';
@@ -8,7 +9,7 @@ import { useRecorder, useTimer } from '../model';
 import { GUIDE_TEXT_BY_LEVEL } from '../model/constants';
 
 const StepRecord = ({ onNext }: { onNext: () => void }) => {
-  const [isMicTestOpen, setIsMicTestOpen] = useState(true);
+  const { open: isMicTestOpen, setOpen: setIsMicTestOpen, closeModal } = useModal(true);
   const [micGain, setMicGain] = useState(1);
 
   const { phase, start, pause, finish, handleRecorded } = useRecorder();
@@ -28,16 +29,12 @@ const StepRecord = ({ onNext }: { onNext: () => void }) => {
     <>
       {/* 마이크 테스트 모달 */}
       {isMicTestOpen && (
-        <MicTestModal
-          gain={micGain}
-          onChangeGain={setMicGain}
-          onClose={() => setIsMicTestOpen(false)}
-        />
+        <MicTestModal gain={micGain} onChangeGain={setMicGain} onClose={closeModal} />
       )}
 
       <div className='pt-[4vh] pb-[8vh] flex flex-col gap-4 items-center justify-around max-w-xl h-full'>
         {/* 상태 문구 */}
-        <div className='flex items-center h-[92]'>
+        <div className='flex items-center h-23'>
           <p className='typo-32b text-center whitespace-pre-line'>{guideText}</p>
         </div>
 

--- a/frontend/apps/client/src/shared/assets/icons/ic_plus.svg
+++ b/frontend/apps/client/src/shared/assets/icons/ic_plus.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.9995 8V24" stroke="#C4C4C4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 16.0006H24" stroke="#C4C4C4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/apps/client/src/shared/assets/icons/index.ts
+++ b/frontend/apps/client/src/shared/assets/icons/index.ts
@@ -15,6 +15,7 @@ export { default as IcMore } from './ic_more.svg';
 export { default as IcMy } from './ic_my.svg';
 export { default as IcPause } from './ic_pause.svg';
 export { default as IcPlay } from './ic_play.svg';
+export { default as IcPlus } from './ic_plus.svg';
 export { default as IcRecordingDone } from './ic_recording_done.svg';
 export { default as IcRecordingPause } from './ic_recording_pause.svg';
 export { default as IcRecordingStart } from './ic_recording_start.svg';

--- a/frontend/apps/client/src/shared/components/BaseModal.tsx
+++ b/frontend/apps/client/src/shared/components/BaseModal.tsx
@@ -31,7 +31,10 @@ const BaseModal = ({
       >
         {children}
 
-        <button className='absolute bottom-[-64] w-8 h-8' onClick={onClose}>
+        <button
+          className='absolute -bottom-16 left-1/2 -translate-x-1/2 w-8 h-8 shrink-0 text-gray-300'
+          onClick={onClose}
+        >
           <IcClose />
         </button>
       </div>

--- a/frontend/apps/client/src/shared/components/BaseModal.tsx
+++ b/frontend/apps/client/src/shared/components/BaseModal.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { cn } from '@/shared/lib/cn';
+import { IcClose } from '@/shared/assets/icons';
+
+type BaseModalProps = {
+  onClose: () => void;
+  children: React.ReactNode;
+  className?: string;
+  overlayClassName?: string;
+};
+
+const BaseModal = ({
+  onClose,
+  children,
+  className,
+  overlayClassName,
+}: BaseModalProps) => {
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 z-50 flex items-center justify-center bg-dim',
+        overlayClassName
+      )}
+    >
+      <div
+        role='dialog'
+        aria-modal='true'
+        className={cn('relative', className)}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+
+        <button className='absolute bottom-[-64] w-8 h-8' onClick={onClose}>
+          <IcClose />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default BaseModal;

--- a/frontend/apps/client/src/shared/components/index.ts
+++ b/frontend/apps/client/src/shared/components/index.ts
@@ -1,3 +1,4 @@
+export { default as BaseModal } from './BaseModal';
 export { default as GenreCard } from './GenreCard';
 export { default as SectionTab } from './SectionTab';
 export { default as SelectChip } from './SelectChip';

--- a/frontend/apps/client/src/shared/hooks/index.ts
+++ b/frontend/apps/client/src/shared/hooks/index.ts
@@ -1,1 +1,2 @@
+export { default as useModal } from './useModal';
 export { default as useSectionTab } from './useSectionTab';

--- a/frontend/apps/client/src/shared/hooks/useModal.ts
+++ b/frontend/apps/client/src/shared/hooks/useModal.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+const useModal = (initialOpen = false) => {
+  const [open, setOpen] = useState(initialOpen);
+
+  const openModal = useCallback(() => setOpen(true), []);
+  const closeModal = useCallback(() => setOpen(false), []);
+  const toggleModal = useCallback(() => setOpen((v) => !v), []);
+
+  return { open, setOpen, openModal, closeModal, toggleModal };
+};
+
+export default useModal;

--- a/frontend/apps/client/src/shared/lib/selection.ts
+++ b/frontend/apps/client/src/shared/lib/selection.ts
@@ -1,0 +1,19 @@
+export const nextSelectedWithAll = <T extends string>(
+  prev: ReadonlySet<T | 'all'>,
+  key: T | 'all'
+): Set<T | 'all'> => {
+  const next = new Set(prev);
+
+  if (key === 'all') {
+    return new Set(['all']);
+  }
+
+  if (next.has('all')) next.delete('all');
+
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
+
+  if (next.size === 0) next.add('all');
+
+  return next;
+};

--- a/frontend/apps/client/src/widgets/library/ui/LibraryBanner.tsx
+++ b/frontend/apps/client/src/widgets/library/ui/LibraryBanner.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { cn } from '@/shared/lib/cn';
+
+const LibraryBanner = () => {
+  return (
+    <section
+      className={cn(
+        'px-8 py-14 flex flex-col justify-center w-full h-56.25 bg-linear-to-b from-yellow-900/50 to-bg'
+      )}
+    >
+      <div className='flex flex-col gap-1'>
+        <span className='typo-18sb text-gray-400'>노래방 키트</span>
+        <h1 className='typo-32b text-white'>
+          노래방에서 찜한 노래와 보컬 기록을 확인하며 노래해보세요!
+        </h1>
+      </div>
+    </section>
+  );
+};
+
+export default LibraryBanner;

--- a/frontend/apps/client/src/widgets/library/ui/LibraryHistoryList.tsx
+++ b/frontend/apps/client/src/widgets/library/ui/LibraryHistoryList.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Button } from '@singchronize/ui';
+import { cn } from '@/shared/lib/cn';
+import { nextSelectedWithAll } from '@/shared/lib/selection';
+import { HistoryItem } from '@/entities/library/ui';
+import { SelectChip } from '@/shared/components';
+import { HISTORY_TAG_OPTIONS, HistoryTagType } from '@/entities/library/model/tags';
+import { MOCK_HISTORY_ITEMS } from '@/entities/library/model/mock';
+
+type TagKey = 'all' | HistoryTagType;
+
+const LibraryHistoryList = () => {
+  const [selected, setSelected] = useState<Set<TagKey>>(() => new Set(['all']));
+
+  const toggleTag = (key: TagKey) => {
+    setSelected((prev) => nextSelectedWithAll(prev, key));
+  };
+
+  // TODO: 추후에 API로 교체
+  const items = useMemo(() => {
+    if (selected.has('all')) return MOCK_HISTORY_ITEMS;
+
+    const selectedTags = Array.from(selected) as HistoryTagType[];
+    return MOCK_HISTORY_ITEMS.filter((item) =>
+      selectedTags.some((tag) => (item.tags ?? []).includes(tag))
+    );
+  }, [selected]);
+
+  const handleAddClick = () => {
+    // TODO: 추후에 모달/페이지 이동/폼 열기 등으로 교체
+    console.log('보컬기록 추가하기');
+  };
+
+  return (
+    <section className='mt-4 mb-6 flex flex-col gap-6'>
+      <div className={cn('w-full flex items-center justify-between gap-6')}>
+        <div className={cn('flex items-center gap-2 overflow-x-auto scrollbar-hide')}>
+          {HISTORY_TAG_OPTIONS.map((opt) => (
+            <SelectChip
+              key={opt.key}
+              label={opt.label}
+              selected={selected.has(opt.key)}
+              onClick={() => toggleTag(opt.key)}
+            />
+          ))}
+        </div>
+
+        <Button variant='normal' onClick={handleAddClick}>
+          보컬기록 추가하기
+        </Button>
+      </div>
+
+      <div className='flex flex-col gap-6'>
+        {items.map((item) => (
+          <HistoryItem key={item.historyId} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default LibraryHistoryList;

--- a/frontend/apps/client/src/widgets/library/ui/LibraryHistoryList.tsx
+++ b/frontend/apps/client/src/widgets/library/ui/LibraryHistoryList.tsx
@@ -2,17 +2,21 @@
 
 import { useMemo, useState } from 'react';
 import { Button } from '@singchronize/ui';
+import { SelectChip } from '@/shared/components';
 import { cn } from '@/shared/lib/cn';
 import { nextSelectedWithAll } from '@/shared/lib/selection';
 import { HistoryItem } from '@/entities/library/ui';
-import { SelectChip } from '@/shared/components';
-import { HISTORY_TAG_OPTIONS, HistoryTagType } from '@/entities/library/model/tags';
+import { HISTORY_FILTER_OPTIONS, HistoryTagType } from '@/entities/library/model/tags';
+import { useModal } from '@/shared/hooks';
+import { AddHistoryModal } from '@/features/add-history/ui';
+
 import { MOCK_HISTORY_ITEMS } from '@/entities/library/model/mock';
 
 type TagKey = 'all' | HistoryTagType;
 
 const LibraryHistoryList = () => {
   const [selected, setSelected] = useState<Set<TagKey>>(() => new Set(['all']));
+  const { open: isAddModalOpen, openModal, closeModal } = useModal(false);
 
   const toggleTag = (key: TagKey) => {
     setSelected((prev) => nextSelectedWithAll(prev, key));
@@ -29,35 +33,38 @@ const LibraryHistoryList = () => {
   }, [selected]);
 
   const handleAddClick = () => {
-    // TODO: 추후에 모달/페이지 이동/폼 열기 등으로 교체
-    console.log('보컬기록 추가하기');
+    openModal();
   };
 
   return (
-    <section className='mt-4 mb-6 flex flex-col gap-6'>
-      <div className={cn('w-full flex items-center justify-between gap-6')}>
-        <div className={cn('flex items-center gap-2 overflow-x-auto scrollbar-hide')}>
-          {HISTORY_TAG_OPTIONS.map((opt) => (
-            <SelectChip
-              key={opt.key}
-              label={opt.label}
-              selected={selected.has(opt.key)}
-              onClick={() => toggleTag(opt.key)}
-            />
-          ))}
+    <>
+      <section className='mt-4 mb-6 flex flex-col gap-6'>
+        <div className={cn('w-full flex items-center justify-between gap-6')}>
+          <div className={cn('flex items-center gap-2 overflow-x-auto scrollbar-hide')}>
+            {HISTORY_FILTER_OPTIONS.map((opt) => (
+              <SelectChip
+                key={opt.key}
+                label={opt.label}
+                selected={selected.has(opt.key)}
+                onClick={() => toggleTag(opt.key)}
+              />
+            ))}
+          </div>
+
+          <Button variant='normal' onClick={handleAddClick}>
+            보컬기록 추가하기
+          </Button>
         </div>
 
-        <Button variant='normal' onClick={handleAddClick}>
-          보컬기록 추가하기
-        </Button>
-      </div>
+        <div className='flex flex-col gap-6'>
+          {items.map((item) => (
+            <HistoryItem key={item.historyId} item={item} />
+          ))}
+        </div>
+      </section>
 
-      <div className='flex flex-col gap-6'>
-        {items.map((item) => (
-          <HistoryItem key={item.historyId} item={item} />
-        ))}
-      </div>
-    </section>
+      {isAddModalOpen && <AddHistoryModal onClose={closeModal} />}
+    </>
   );
 };
 

--- a/frontend/apps/client/src/widgets/library/ui/index.ts
+++ b/frontend/apps/client/src/widgets/library/ui/index.ts
@@ -1,0 +1,2 @@
+export { default as LibraryBanner } from './LibraryBanner';
+export { default as LibraryHistoryList } from './LibraryHistoryList';

--- a/frontend/packages/ui/src/components/button/Button.tsx
+++ b/frontend/packages/ui/src/components/button/Button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../../lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-[10px] px-6 py-[10px] rounded-full typo-18sb text-center transition-colors cursor-pointer disabled:pointer-events-none',
+  'inline-flex items-center justify-center gap-[10px] px-6 py-[10px] rounded-full typo-18sb text-center shrink-0 transition-colors cursor-pointer disabled:pointer-events-none',
   {
     variants: {
       variant: {

--- a/frontend/packages/ui/src/components/index.ts
+++ b/frontend/packages/ui/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as Button } from './button/Button';
 export * from './dialog/Dialog';
 export * from './tooltip/Tooltip';
 export { default as InputField } from './inputfield/InputField';
+export { default as TextAreaField } from './textareafield/TextAreaField';

--- a/frontend/packages/ui/src/components/textareafield/TextAreaField.tsx
+++ b/frontend/packages/ui/src/components/textareafield/TextAreaField.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { forwardRef, useLayoutEffect, useRef } from 'react';
+import { cn } from '../../lib/utils';
+
+type TextAreaFieldProps = Omit<
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+  'size'
+> & {
+  minRows?: number; // 최소 줄 수
+  maxRows?: number; // 최대 줄 수
+};
+
+const getLineHeightPx = (el: HTMLTextAreaElement) => {
+  const lineHeight = window.getComputedStyle(el).lineHeight;
+  const parsed = Number.parseFloat(lineHeight);
+  return Number.isFinite(parsed) ? parsed : 24; // fallback
+};
+
+const TextAreaField = forwardRef<HTMLTextAreaElement, TextAreaFieldProps>(
+  ({ className, onChange, value, defaultValue, minRows = 1, maxRows, ...props }, ref) => {
+    const innerRef = useRef<HTMLTextAreaElement | null>(null);
+
+    const setRefs = (node: HTMLTextAreaElement | null) => {
+      innerRef.current = node;
+
+      if (typeof ref === 'function') ref(node);
+      else if (ref) ref.current = node;
+    };
+
+    const resize = (el: HTMLTextAreaElement) => {
+      el.style.height = 'auto';
+
+      const lineHeight = getLineHeightPx(el);
+      const minHeight = lineHeight * minRows;
+
+      let nextHeight = Math.max(el.scrollHeight, minHeight);
+
+      if (typeof maxRows === 'number') {
+        const maxHeight = lineHeight * maxRows;
+        nextHeight = Math.min(nextHeight, maxHeight);
+        el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
+      } else {
+        el.style.overflowY = 'hidden';
+      }
+
+      el.style.height = `${nextHeight}px`;
+    };
+
+    useLayoutEffect(() => {
+      const el = innerRef.current;
+      if (!el) return;
+      resize(el);
+    }, [value, defaultValue, minRows, maxRows]);
+
+    return (
+      <div className={cn('px-6 py-4 flex w-full items-start rounded-10 bg-gray-800')}>
+        <textarea
+          {...props}
+          ref={setRefs}
+          value={value as any}
+          defaultValue={defaultValue}
+          onChange={(e) => {
+            resize(e.currentTarget);
+            onChange?.(e);
+          }}
+          className={cn(
+            'w-full border-none bg-transparent outline-none resize-none overflow-hidden',
+            'typo-16r text-gray-100',
+            'placeholder:text-gray-500',
+            'caret-gray-100',
+            className
+          )}
+        />
+      </div>
+    );
+  }
+);
+
+TextAreaField.displayName = 'TextAreaField';
+
+export default TextAreaField;


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #58


## 📤 Tasks
<!-- 해당 PR에 대한 작업 내용을 작성해주세요. -->
- 노래방 키트 페이지 보컬 기록 UI 구현
- 모달 / TextAreaField 공통 컴포넌트 구현

키트 페이지 찜 리스트의 경우 전면적인 디자인 수정이 있을 예정이라 수정이 완료되면 구현할 예정입니다.

<br/>

## 📸 Screenshot
<!-- 관련 스크린샷을 첨부해주세요. -->
<img width="716" height="510" alt="스크린샷 2026-03-02 오후 10 54 32" src="https://github.com/user-attachments/assets/bb56aa60-0938-466c-b45f-8af3762da31d" />
<img width="716" height="510" alt="스크린샷 2026-03-02 오후 10 55 16" src="https://github.com/user-attachments/assets/8fbbecff-4795-42d1-a912-e930384d836a" />
<img width="716" height="510" alt="스크린샷 2026-03-02 오후 10 55 27" src="https://github.com/user-attachments/assets/ba8abf2e-dced-49b9-a4e5-1b95ab4b3460" />

<br/>
