### PR TITLE
Fix(server): 외부 API 비동기 호출 구조 개선

### DIFF
--- a/backend/app/routers/songs.py
+++ b/backend/app/routers/songs.py
@@ -8,15 +8,16 @@ spotify = SpotifyService(settings.SPOTIFY_CLIENT_ID, settings.SPOTIFY_CLIENT_SEC
 
 @router.get("/search")
 async def search_music(q: str):
-    results = spotify.search_tracks(q)
-    
+    results = await spotify.search_tracks(q)
+
     # 필요한 정보(제목, 가수, 앨범커버, URI)만 추려서 프론트에 전달
     tracks = []
     for item in results.get("tracks", {}).get("items", []):
+        images = item["album"].get("images", [])
         tracks.append({
             "name": item["name"],
             "artist": item["artists"][0]["name"],
-            "album_image": item["album"]["images"][0]["url"],
-            "uri": item["uri"] # 나중에 재생할 때 필수!
+            "album_image": images[0]["url"] if images else None,
+            "uri": item["uri"],
         })
     return tracks

--- a/backend/app/services/spotify.py
+++ b/backend/app/services/spotify.py
@@ -1,56 +1,56 @@
 import base64
-import requests
+import logging
+import httpx
+
+logger = logging.getLogger(__name__)
+
 
 class SpotifyService:
     def __init__(self, client_id: str, client_secret: str):
         self.client_id = client_id
         self.client_secret = client_secret
-        self.access_token = None
+        self.access_token: str | None = None
 
-    def get_token(self):
+    async def _get_token(self, client: httpx.AsyncClient) -> None:
         """스포티파이로부터 1시간짜리 Access Token을 받아옵니다."""
-        # Client ID와 Secret을 결합하여 Base64로 인코딩 (OAuth2 규격)
         auth_str = f"{self.client_id}:{self.client_secret}"
         auth_base64 = base64.b64encode(auth_str.encode()).decode()
 
-        url = "https://accounts.spotify.com/api/token"
-        headers = {
-            "Authorization": f"Basic {auth_base64}",
-            "Content-Type": "application/x-www-form-urlencoded"
-        }
-        data = {"grant_type": "client_credentials"}
-        
-        try:
-            response = requests.post(url, headers=headers, data=data)
-            response.raise_for_status() # 에러 발생 시 예외 처리
-            
-            self.access_token = response.json()["access_token"]
-            return self.access_token
-        except Exception as e:
-            print(f"❌ 토큰 발급 실패: {e}")
-            return None
+        response = await client.post(
+            "https://accounts.spotify.com/api/token",
+            headers={
+                "Authorization": f"Basic {auth_base64}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            data={"grant_type": "client_credentials"},
+        )
+        response.raise_for_status()
+        self.access_token = response.json()["access_token"]
 
-    def search_tracks(self, query: str):
+    async def search_tracks(self, query: str) -> dict:
         """노래 제목으로 검색하여 결과를 반환합니다."""
-        # 토큰이 없으면 새로 받아오기
-        if not self.access_token:
-            self.get_token()
+        async with httpx.AsyncClient() as client:
+            if not self.access_token:
+                await self._get_token(client)
 
-        url = "https://api.spotify.com/v1/search"
-        headers = {"Authorization": f"Bearer {self.access_token}"}
-        # q: 검색어, type: 트랙(노래), limit: 10개, market: 한국 기준
-        params = {"q": query, "type": "track", "limit": 10, "market": "KR"}
-        
-        try:
-            response = requests.get(url, headers=headers, params=params)
-            
-            # 만약 토큰이 만료되어 401 에러가 나면 갱신 후 재시도
+            params = {"q": query, "type": "track", "limit": 10, "market": "KR"}
+            headers = {"Authorization": f"Bearer {self.access_token}"}
+
+            response = await client.get(
+                "https://api.spotify.com/v1/search",
+                headers=headers,
+                params=params,
+            )
+
+            # 토큰 만료 시 갱신 후 재시도
             if response.status_code == 401:
-                self.get_token()
+                await self._get_token(client)
                 headers["Authorization"] = f"Bearer {self.access_token}"
-                response = requests.get(url, headers=headers, params=params)
-                
+                response = await client.get(
+                    "https://api.spotify.com/v1/search",
+                    headers=headers,
+                    params=params,
+                )
+
+            response.raise_for_status()
             return response.json()
-        except Exception as e:
-            print(f"❌ 검색 실패: {e}")
-            return {"error": str(e)}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,4 +19,3 @@ pydantic-settings==2.7.0
 
 # OpenAPI export
 pyyaml==6.0.2
-requests


### PR DESCRIPTION
## 📌 Related Issue

- Closes #91 


## 📤 Tasks

- [x] `spotify.py`의 외부 API 호출을 동기 방식에서 비동기 방식으로 전환
- [x] `songs.py`의 외부 API 호출을 동기 방식에서 비동기 방식으로 전환
- [x] `requests` 기반 호출을 `httpx.AsyncClient`로 변경
- [x] FastAPI 비동기 흐름에 맞게 호출 구조 정리
- [x] 외부 API 응답 처리 로직 점검 및 유지
- [x] `album.images`가 빈 리스트일 때 발생할 수 있는 예외 처리 보완
- [x] `requirements.txt`에서 불필요한 `requests` 의존성 제거
- [x] 비동기 HTTP 클라이언트 사용에 맞게 의존성 정리

<br/>

## 📸 Screenshot

- 해당 없음

<br/>

## 💌 To Reviewer

- FastAPI의 비동기 처리 흐름에 맞추기 위해 외부 API 호출을 `httpx.AsyncClient` 기반으로 변경했습니다.
- 기능 변경보다는 성능 및 구조 일관성 개선에 초점을 둔 PR입니다.
- `spotify.py`, `songs.py`의 호출 방식 변경과 응답 처리 부분을 중점적으로 봐주시면 감사하겠습니다.

<br/>