### PR TITLE
Feat(server): 가수 검색 API 구현

### DIFF
--- a/backend/app/routers/singers.py
+++ b/backend/app/routers/singers.py
@@ -6,9 +6,27 @@ from app.database import get_db
 from app.dependencies.auth import get_current_user
 from app.models.user import User
 from app.services.singer_service import SingerService
-from app.schemas.singer import RandomSingersResponse, SingerInfo
+from app.schemas.singer import RandomSingersResponse, SingerInfo, SingerSearchResponse
 
 router = APIRouter(prefix="/api/v1/singers", tags=["Singers"])
+
+
+@router.get("/search", response_model=SingerSearchResponse)
+async def search_singers(
+    q: str = Query(..., min_length=1, description="검색할 가수 이름"),
+    limit: int = Query(10, ge=1, le=30),
+    _: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """가수 이름 또는 별칭으로 검색 (부분 일치)"""
+    service = SingerService(db)
+    singers = await service.search_singers(query=q, limit=limit)
+    return SingerSearchResponse(
+        singers=[
+            SingerInfo(singer_id=s.singer_id, name=s.name, photo_url=s.photo_url)
+            for s in singers
+        ]
+    )
 
 
 @router.get("/random", response_model=RandomSingersResponse)

--- a/backend/app/schemas/singer.py
+++ b/backend/app/schemas/singer.py
@@ -18,6 +18,10 @@ class RandomSingersResponse(BaseModel):
     singers: List[SingerInfo]
 
 
+class SingerSearchResponse(BaseModel):
+    singers: List[SingerInfo]
+
+
 # ── Blocked Singer ───────────────────────────────────
 
 class BlockSingerRequest(BaseModel):

--- a/backend/app/services/singer_service.py
+++ b/backend/app/services/singer_service.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from typing import List
 
 from fastapi import HTTPException, status
-from sqlalchemy import select, func, text
+from sqlalchemy import select, func, text, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -43,6 +43,20 @@ class SingerService:
             .limit(limit)
         )
 
+        result = await self.db.execute(stmt)
+        return result.scalars().all()
+
+    # ─── 가수 검색 ───────────────────────────────────
+
+    async def search_singers(self, query: str, limit: int) -> List[Singer]:
+        """이름 또는 별칭으로 가수 검색 (부분 일치)"""
+        q = f"%{query}%"
+        stmt = (
+            select(Singer)
+            .where(or_(Singer.name.ilike(q), Singer.aliases.ilike(q)))
+            .order_by(Singer.name)
+            .limit(limit)
+        )
         result = await self.db.execute(stmt)
         return result.scalars().all()
 


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #101 


## 📤 Tasks

- 가수 검색 API를 구현했습니다.
- `GET /api/v1/singers/search?q={검색어}&limit={최대수}` 엔드포인트를 추가했습니다.
- `name`, `aliases` 컬럼에 대해 부분 일치 검색이 가능하도록 적용했습니다.
- 대소문자를 구분하지 않고 검색할 수 있도록 처리했습니다.
- `limit` 기본값은 10으로 설정하고, 최대 30까지 제한되도록 반영했습니다.
- 인증이 필요한 API로 설정했습니다. (`Authorization: Bearer ...`)
- 응답 형식은 아래와 같이 반환되도록 구현했습니다.

```json
{
  "singers": [
    {
      "singer_id": 1,
      "name": "아이유",
      "photo_url": "https://..."
    }
  ]
}
````

<br/>

## 📸 Screenshot

<img width="1041" height="634" alt="image" src="https://github.com/user-attachments/assets/a517d320-9c6d-4042-b330-be66f28495de" />
<br/>

## 💌 To Reviewer

* `name`, `aliases` 모두 부분 일치 검색 대상으로 포함했습니다.
* 현재 응답값은 `singer_id`, `name`, `photo_url`만 내려가도록 최소화했습니다.
* `limit` 상한을 30으로 두었는데, 검색 UX 상 더 적절한 값이 있으면 의견 부탁드립니다.

<br/>

