### PR TITLE
Feat(server): 온보딩 1단계(프로필 이미지, 닉네임) API 구현

### DIFF
--- a/backend/app/routers/onboarding.py
+++ b/backend/app/routers/onboarding.py
@@ -1,0 +1,88 @@
+"""온보딩 라우터 - 회원가입 후 초기 프로필 설정"""
+import time
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.user import User
+from app.schemas.user import UserResponse
+from app.services.user_service import UserService
+from app.utils.aws import upload_image_to_s3
+
+router = APIRouter(prefix="/api/v1/users/me/onboarding", tags=["Onboarding"])
+
+_ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp"}
+_MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5 MB
+_MAX_NICKNAME_LEN = 20
+
+
+@router.post(
+    "/step1",
+    response_model=UserResponse,
+    status_code=status.HTTP_200_OK,
+    summary="프로필 설정 1단계",
+    description=(
+        "회원가입 직후 온보딩 1단계. "
+        "닉네임(필수)과 프로필 사진(선택)을 설정합니다. "
+        "`multipart/form-data`로 전송하세요."
+    ),
+)
+async def onboarding_step1(
+    nickname: str = Form(..., description="닉네임 (1~20자, 공백만 불가)"),
+    profile_image: Optional[UploadFile] = File(None, description="프로필 사진 (jpeg/png/webp, 최대 5MB)"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> UserResponse:
+    # ── 닉네임 검증 ──────────────────────────────────────
+    stripped = nickname.strip()
+    if not stripped:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"code": "INVALID_NICKNAME", "message": "닉네임은 공백만으로 구성될 수 없습니다."},
+        )
+    if len(stripped) > _MAX_NICKNAME_LEN:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"code": "NICKNAME_TOO_LONG", "message": f"닉네임은 최대 {_MAX_NICKNAME_LEN}자입니다."},
+        )
+
+    # ── 프로필 사진 업로드 ────────────────────────────────
+    profile_img_url: Optional[str] = None
+    if profile_image and profile_image.filename:
+        content_type = profile_image.content_type or ""
+        if content_type not in _ALLOWED_IMAGE_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                detail={"code": "INVALID_IMAGE_TYPE", "message": "jpeg, png, webp 이미지만 업로드 가능합니다."},
+            )
+        file_bytes = await profile_image.read()
+        if len(file_bytes) > _MAX_IMAGE_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail={"code": "IMAGE_TOO_LARGE", "message": "이미지 크기는 5MB 이하여야 합니다."},
+            )
+        ext = content_type.split("/")[-1]
+        key = f"profiles/{current_user.id}/{int(time.time())}.{ext}"
+        url = upload_image_to_s3(file_bytes, key, content_type)
+        if url is None:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail={"code": "S3_UPLOAD_FAILED", "message": "프로필 사진 업로드에 실패했습니다."},
+            )
+        profile_img_url = url
+
+    # ── 서비스 레이어 ─────────────────────────────────────
+    service = UserService(db)
+    updated = await service.setup_onboarding_step1(
+        user_id=current_user.id,
+        nickname=stripped,
+        profile_img_url=profile_img_url,
+    )
+
+    await db.commit()
+    await db.refresh(updated)
+
+    return UserResponse.model_validate(updated, from_attributes=True)

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -30,6 +30,23 @@ class UserService:
         await self.db.flush()
         return user
 
+    async def setup_onboarding_step1(
+        self,
+        user_id: uuid.UUID,
+        nickname: str,
+        profile_img_url: str | None = None,
+    ) -> User:
+        """온보딩 1단계: 닉네임 + 프로필 사진 저장 후 완료 상태 반영"""
+        user = await self.get_user(user_id)
+        user.nickname = nickname
+        if profile_img_url is not None:
+            user.profile_img = profile_img_url
+        settings_data = dict(user.settings or {})
+        settings_data["onboarding_step"] = 1
+        user.settings = settings_data
+        await self.db.flush()
+        return user
+
     async def update_settings(
         self,
         user_id: uuid.UUID,

--- a/backend/app/utils/aws.py
+++ b/backend/app/utils/aws.py
@@ -34,6 +34,21 @@ def generate_presigned_url(object_name, expiration=3600):
         return None
     return response
 
+def upload_image_to_s3(file_bytes: bytes, key: str, content_type: str = "image/jpeg") -> str | None:
+    """S3에 이미지를 직접 업로드하고 public URL 반환"""
+    try:
+        s3_client.put_object(
+            Bucket=settings.S3_BUCKET_NAME,
+            Key=key,
+            Body=file_bytes,
+            ContentType=content_type,
+        )
+        return f"https://{settings.S3_BUCKET_NAME}.s3.{settings.AWS_REGION}.amazonaws.com/{key}"
+    except ClientError as e:
+        print(f"❌ S3 이미지 업로드 실패: {e}")
+        return None
+
+
 def send_sqs_message(message_body):
     """SQS 큐에 추천 작업 메시지 전송"""
     try:

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,7 @@ from app.config import settings
 from app.database import init_db
 from app.routers import auth, user, songs, library, busking, recommendations, singers
 from app.routers.oauth_test import router as oauth_test_router
+from app.routers.onboarding import router as onboarding_router
 from fastapi.staticfiles import StaticFiles
 
 
@@ -39,6 +40,7 @@ app.include_router(library.router)
 app.include_router(busking.router)
 app.include_router(recommendations.router)
 app.include_router(singers.router)
+app.include_router(onboarding_router)
 app.include_router(oauth_test_router)
 
 @app.get("/health", status_code=status.HTTP_200_OK)


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #103 


## 📤 Tasks

- 회원가입 후 프로필 설정 1단계 API를 구현했습니다.
- OAuth를 통해 로그인한 유저 기준으로 동작하도록 구성했습니다.
- 닉네임과 프로필 사진을 저장할 수 있도록 처리했습니다.
- 닉네임 validation을 추가했습니다.
  - 빈 문자열 불가
  - 공백만 있는 값 불가
  - 최대 길이 제한 적용
- 프로필 사진 업로드는 기존 업로드/S3 유틸을 재사용하도록 반영했습니다.
- 필요 시 온보딩 1단계 완료 상태를 함께 반영할 수 있도록 구현했습니다.
- request/response schema를 정리하고 기존 프로젝트 응답 패턴에 맞추었습니다.

### 구현 대상
- 프로필 사진 업로드
- 닉네임 설정
- 로그인 유저 기준 초기 프로필 설정 처리

### 기대 효과
- 회원가입 직후 유저가 기본 프로필을 설정할 수 있습니다.
- 온보딩 1단계와 이후 마이페이지 수정 기능의 역할을 분리할 수 있습니다.
- 이후 온보딩 2단계와 자연스럽게 연계할 수 있습니다.

<br/>

## 📸 Screenshot
<img width="1044" height="582" alt="image" src="https://github.com/user-attachments/assets/fd2cc268-4575-41e8-9f06-3cbbd3b0508d" />

<br/>

## 💌 To Reviewer

<br/>