### PR TITLE
Feat(server): 온보딩 2단계 (좋아하는 가수 선택) API 구현

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,6 @@ from app.models.song import Song
 from app.models.library import Folder, WishlistItem
 from app.models.archive import Archive
 from app.models.recommendation import Recommendation
-from app.models.singer import Singer, BlockedSinger
+from app.models.singer import Singer, BlockedSinger, FavoriteSinger
 
-__all__ = ["User", "RefreshToken", "Song", "Folder", "WishlistItem", "Archive", "Recommendation", "Singer", "BlockedSinger"]
+__all__ = ["User", "RefreshToken", "Song", "Folder", "WishlistItem", "Archive", "Recommendation", "Singer", "BlockedSinger", "FavoriteSinger"]

--- a/backend/app/models/singer.py
+++ b/backend/app/models/singer.py
@@ -1,4 +1,4 @@
-"""Singer & BlockedSinger 모델"""
+"""Singer & BlockedSinger & FavoriteSinger 모델"""
 from sqlalchemy import Column, String, Integer, DateTime, ForeignKey, Uuid, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
@@ -20,6 +20,7 @@ class Singer(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     blocked_by = relationship("BlockedSinger", back_populates="singer", cascade="all, delete-orphan")
+    favorited_by = relationship("FavoriteSinger", back_populates="singer", cascade="all, delete-orphan")
 
 
 class BlockedSinger(Base):
@@ -34,4 +35,19 @@ class BlockedSinger(Base):
 
     __table_args__ = (
         UniqueConstraint("user_id", "singer_id", name="uq_user_singer_block"),
+    )
+
+
+class FavoriteSinger(Base):
+    __tablename__ = "favorite_singers"
+
+    favorite_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Uuid, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    singer_id = Column(Integer, ForeignKey("singers.singer_id", ondelete="CASCADE"), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    singer = relationship("Singer", back_populates="favorited_by")
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "singer_id", name="uq_user_singer_favorite"),
     )

--- a/backend/app/routers/onboarding.py
+++ b/backend/app/routers/onboarding.py
@@ -8,7 +8,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.dependencies.auth import get_current_user
 from app.models.user import User
+from app.schemas.singer import FavoriteSingersSelectRequest, FavoriteSingersSelectResponse, SingerInfo
 from app.schemas.user import UserResponse
+from app.services.singer_service import SingerService
 from app.services.user_service import UserService
 from app.utils.aws import upload_image_to_s3
 
@@ -86,3 +88,40 @@ async def onboarding_step1(
     await db.refresh(updated)
 
     return UserResponse.model_validate(updated, from_attributes=True)
+
+
+@router.post(
+    "/step2",
+    response_model=FavoriteSingersSelectResponse,
+    status_code=status.HTTP_200_OK,
+    summary="즐겨부르는 가수 선택 (온보딩 2단계)",
+    description=(
+        "가수 ID 목록을 받아 즐겨부르는 가수로 저장합니다. "
+        "기존 선택을 전부 교체하므로 마이페이지 수정 시에도 동일하게 호출할 수 있습니다. "
+        "가수 목록은 `GET /api/v1/singers/random` API로 조회하세요."
+    ),
+)
+async def onboarding_step2(
+    body: FavoriteSingersSelectRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> FavoriteSingersSelectResponse:
+    service = SingerService(db)
+    singers = await service.select_favorite_singers(
+        user_id=current_user.id,
+        singer_ids=body.singer_ids,
+    )
+
+    # 온보딩 2단계 완료 상태 반영
+    user_service = UserService(db)
+    await user_service.update_settings(
+        user_id=current_user.id,
+        update_data={"onboarding_step": 2},
+    )
+
+    return FavoriteSingersSelectResponse(
+        singers=[
+            SingerInfo(singer_id=s.singer_id, name=s.name, photo_url=s.photo_url)
+            for s in singers
+        ]
+    )

--- a/backend/app/schemas/singer.py
+++ b/backend/app/schemas/singer.py
@@ -1,5 +1,5 @@
 """Singer 스키마"""
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import List, Optional
 from datetime import datetime
 
@@ -19,6 +19,25 @@ class RandomSingersResponse(BaseModel):
 
 
 class SingerSearchResponse(BaseModel):
+    singers: List[SingerInfo]
+
+
+# ── Favorite Singers (온보딩 2단계) ──────────────────
+
+class FavoriteSingersSelectRequest(BaseModel):
+    singer_ids: List[int]
+
+    @field_validator("singer_ids")
+    @classmethod
+    def validate_singer_ids(cls, v: List[int]) -> List[int]:
+        if not v:
+            raise ValueError("가수를 최소 1명 이상 선택해야 합니다.")
+        if len(v) != len(set(v)):
+            raise ValueError("중복된 가수 ID가 포함되어 있습니다.")
+        return v
+
+
+class FavoriteSingersSelectResponse(BaseModel):
     singers: List[SingerInfo]
 
 

--- a/backend/app/services/singer_service.py
+++ b/backend/app/services/singer_service.py
@@ -3,11 +3,11 @@ from uuid import UUID
 from typing import List
 
 from fastapi import HTTPException, status
-from sqlalchemy import select, func, text, or_
+from sqlalchemy import select, func, text, or_, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.singer import Singer, BlockedSinger
+from app.models.singer import Singer, BlockedSinger, FavoriteSinger
 
 
 VALID_GENDERS = {"male", "female"}
@@ -58,6 +58,39 @@ class SingerService:
             .limit(limit)
         )
         result = await self.db.execute(stmt)
+        return result.scalars().all()
+
+    # ─── 즐겨찾는 가수 선택 (온보딩 2단계) ──────────────
+
+    async def select_favorite_singers(
+        self, user_id: UUID, singer_ids: List[int]
+    ) -> List[Singer]:
+        """기존 즐겨찾기를 전부 교체 후 새로 저장 (onboarding step2 / 마이페이지 수정 공용)"""
+        # 요청된 singer_id가 실제로 존재하는지 한 번에 검증
+        exists_result = await self.db.execute(
+            select(Singer.singer_id).where(Singer.singer_id.in_(singer_ids))
+        )
+        found_ids = set(exists_result.scalars().all())
+        missing = set(singer_ids) - found_ids
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"code": "SINGER_NOT_FOUND", "message": f"존재하지 않는 가수 ID: {sorted(missing)}"},
+            )
+
+        # 기존 즐겨찾기 전체 삭제 후 재삽입 (교체 방식)
+        await self.db.execute(
+            delete(FavoriteSinger).where(FavoriteSinger.user_id == user_id)
+        )
+        self.db.add_all([
+            FavoriteSinger(user_id=user_id, singer_id=sid) for sid in singer_ids
+        ])
+        await self.db.flush()
+
+        # 저장된 Singer 정보 반환
+        result = await self.db.execute(
+            select(Singer).where(Singer.singer_id.in_(singer_ids)).order_by(Singer.name)
+        )
         return result.scalars().all()
 
     # ─── 가수 차단 등록 ───────────────────────────────


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #106


## 📤 Tasks

- 회원가입 후 프로필 설정 2단계인 즐겨부르는 가수 선택 API를 구현했습니다.
- 인증된 사용자 기준으로 여러 명의 가수를 선택하여 저장할 수 있도록 처리했습니다.
- 기존 랜덤 가수 조회 API와 자연스럽게 연계될 수 있도록 고려했습니다.
- 유저와 가수의 다대다 관계를 저장할 수 있는 구조를 반영했습니다.
- 같은 가수를 중복 선택하지 못하도록 처리했습니다.
- request/response schema를 정리하고 기존 프로젝트 응답 패턴에 맞추었습니다.
- 필요 시 온보딩 2단계 완료 상태를 함께 반영할 수 있도록 구현했습니다.

### 구현 대상
- 즐겨부르는 가수 다중 선택 저장
- 인증 유저 기준 처리
- 중복 선택 방지
- 저장 구조 및 응답 정리

### 기대 효과
- 회원가입 직후 유저가 자신의 즐겨부르는 가수를 자연스럽게 설정할 수 있습니다.
- 이후 추천/프로필/마이페이지 기능과 연결할 수 있는 기반을 마련할 수 있습니다.
- 초기 온보딩 2단계와 이후 프로필 수정 기능을 분리하여 확장성을 높일 수 있습니다.

<br/>

## 📸 Screenshot
<img width="1067" height="610" alt="image" src="https://github.com/user-attachments/assets/6fe1006a-968d-423e-944a-66b6d349a7a4" /><br/>

## 💌 To Reviewer

<br/>