### PR TITLE
Feat(server): Songs 상황별 라벨링 자동화 구현

### DIFF
--- a/backend/app/models/song.py
+++ b/backend/app/models/song.py
@@ -1,6 +1,7 @@
 """Song 모델 - Supabase songs 테이블 매핑"""
 import uuid
 from sqlalchemy import Column, String, DateTime, Integer, Uuid
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
 
 from app.database import Base
@@ -12,7 +13,7 @@ class Song(Base):
     id = Column(Uuid, primary_key=True, default=uuid.uuid4)
     title = Column(String, nullable=False, index=True)
     artist = Column(String, nullable=False, index=True)
-    tags = Column(String, nullable=True)
+    tags = Column(JSONB, nullable=True)
     features = Column(String, nullable=True)
     album_cover = Column(String, nullable=True)
     genre = Column(String, nullable=True)

--- a/backend/app/repositories/song_repository.py
+++ b/backend/app/repositories/song_repository.py
@@ -1,0 +1,50 @@
+"""Song 레포지토리 - 상황 태깅용 DB 접근 레이어"""
+import logging
+from typing import List
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.song import Song
+
+logger = logging.getLogger(__name__)
+
+
+class SongRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_untagged_batch(self, batch_size: int, offset: int) -> List[Song]:
+        """situationLabel이 없는 곡을 batch_size 단위로 조회.
+
+        tags가 NULL이거나 tags JSONB 내에 'situationLabel' 키가 없는 경우 포함.
+        """
+        stmt = (
+            select(Song)
+            .where(Song.tags["situationLabel"].is_(None))
+            .order_by(Song.created_at)
+            .limit(batch_size)
+            .offset(offset)
+        )
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def count_untagged(self) -> int:
+        """태깅 대상 곡 전체 수 반환 (진행률 표시용)"""
+        from sqlalchemy import func
+        stmt = select(func.count()).select_from(Song).where(
+            Song.tags["situationLabel"].is_(None)
+        )
+        result = await self.db.execute(stmt)
+        return result.scalar_one()
+
+    async def merge_tags(self, song: Song, new_tags: dict) -> None:
+        """기존 tags JSONB에 new_tags를 merge 저장 (기존 키 보존).
+
+        SQLAlchemy JSON 변경 감지를 위해 새 dict 객체로 교체.
+        """
+        current = dict(song.tags or {})
+        current.update(new_tags)
+        song.tags = current
+        await self.db.flush()
+        logger.debug("[%s] tags 저장 완료: %s", song.id, new_tags)

--- a/backend/app/services/song_tag_service.py
+++ b/backend/app/services/song_tag_service.py
@@ -1,0 +1,118 @@
+"""SongTagService - 상황 라벨 배치 처리 오케스트레이터"""
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import List
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.song import Song
+from app.repositories.song_repository import SongRepository
+from app.utils.openai_client import SituationClassifier
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BatchResult:
+    success: int = 0
+    failed: int = 0
+    errors: List[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return self.success + self.failed
+
+
+class SongTagService:
+    def __init__(self, classifier: SituationClassifier, db: AsyncSession):
+        self._classifier = classifier
+        self._repo = SongRepository(db)
+        self._db = db
+
+    async def process_batch(self, songs: List[Song], sleep_ms: int = 200) -> BatchResult:
+        """주어진 곡 목록에 대해 상황 라벨 분류 후 DB 저장.
+
+        각 곡의 실패는 개별 catch로 처리 → 한 곡 실패가 배치 전체에 영향 없음.
+        성공한 곡들은 배치 끝에 일괄 commit.
+        """
+        result = BatchResult()
+
+        for song in songs:
+            try:
+                classification = await self._classifier.classify(
+                    title=song.title,
+                    artist=song.artist,
+                    genre=song.genre,
+                )
+                await self._repo.merge_tags(song, {
+                    "situationLabel": classification["label"],
+                    "situationReason": classification["reason"],
+                })
+                result.success += 1
+                logger.info("[OK] %s - %s → %s", song.artist, song.title, classification["label"])
+            except Exception as e:
+                result.failed += 1
+                msg = f"[FAIL] {song.artist} - {song.title}: {e}"
+                result.errors.append(msg)
+                logger.warning(msg)
+
+            if sleep_ms > 0:
+                await asyncio.sleep(sleep_ms / 1000)
+
+        if result.success > 0:
+            try:
+                await self._db.commit()
+            except Exception as e:
+                logger.error("DB commit 실패, 롤백: %s", e)
+                await self._db.rollback()
+                result.failed += result.success
+                result.success = 0
+                result.errors.append(f"DB commit 실패: {e}")
+
+        return result
+
+    async def run_all(self, batch_size: int = 20, sleep_ms: int = 200, limit: int = 0) -> BatchResult:
+        """전체 미태깅 곡을 배치로 순회 처리.
+
+        Args:
+            batch_size: 한 번에 처리할 곡 수
+            sleep_ms:   OpenAI 호출 사이 대기 ms
+            limit:      최대 처리 곡 수 (0 = 전체)
+        """
+        accumulated = BatchResult()
+        processed = 0
+
+        total_untagged = await self._repo.count_untagged()
+        target = min(total_untagged, limit) if limit else total_untagged
+        logger.info("처리 대상: %d곡 / 전체 미태깅: %d곡 (batch=%d)", target, total_untagged, batch_size)
+
+        while True:
+            fetch_size = min(batch_size, target - processed) if limit else batch_size
+
+            # 항상 offset=0: commit 후 해당 곡이 untagged 집합에서 제거되므로
+            songs = await self._repo.get_untagged_batch(fetch_size, offset=0)
+            if not songs:
+                logger.info("처리할 곡이 없습니다. 완료.")
+                break
+
+            remaining = await self._repo.count_untagged()
+            logger.info("▶ 배치 처리 | 남은 미태깅: %d곡 | 이번 배치: %d곡", remaining, len(songs))
+
+            try:
+                batch_result = await self.process_batch(songs, sleep_ms=sleep_ms)
+            except Exception as e:
+                logger.error("배치 처리 중 복구 불가 오류: %s", e)
+                break
+
+            accumulated.success += batch_result.success
+            accumulated.failed += batch_result.failed
+            accumulated.errors.extend(batch_result.errors)
+            processed += batch_result.total
+
+            logger.info("✓ 누적 성공: %d  실패: %d", accumulated.success, accumulated.failed)
+
+            if limit and processed >= target:
+                break
+
+        return accumulated

--- a/backend/app/utils/openai_client.py
+++ b/backend/app/utils/openai_client.py
@@ -1,0 +1,169 @@
+"""OpenAI situation classifier — classifies songs into 8 situation labels"""
+import asyncio
+import json
+import logging
+from typing import Optional
+
+from openai import AsyncOpenAI, RateLimitError, APIError
+
+logger = logging.getLogger(__name__)
+
+SITUATION_LABELS = [
+    "회식하며 즐길 때",
+    "가족과 함께할 때",
+    "친구랑 놀 때",
+    "연인과 함께할 때",
+    "공연을 준비할 때",
+    "신나게 놀고 싶을 때",
+    "감성에 젖고 싶을 때",
+    "엔딩곡이 필요할 때",
+]
+
+_SYSTEM_PROMPT = """\
+You are a Korean karaoke song situation classifier.
+Given only the song title, artist, and genre, select the single most fitting label from the 8 options below.
+
+=== Label Criteria ===
+
+1. "회식하며 즐길 때"  (Company dinner / drinking party)
+   - Songs that adults (30s+) love to sing at company dinners or office drinking gatherings
+   - Trot, 7080 hits, classic crowd-pleasers that liven up group settings
+   - Familiar across generations; great for raising the group mood together
+
+2. "가족과 함께할 때"  (Family time)
+   - Wholesome, warm songs suitable for all ages (children to grandparents)
+   - Family outings, holiday gatherings, road trips — clean and heartwarming
+   - Pure, cheerful, feel-good atmosphere
+
+3. "친구랑 놀 때"  (Hanging out with friends)
+   - K-pop, pop, or hip-hop enjoyed by younger crowds (teens~20s) in casual hangouts
+   - Light and fun; fits house parties or outings more than nightclubs
+   - Less formal than a company dinner, less intense than a club rave
+
+4. "연인과 함께할 때"  (Romantic moment with a partner)
+   - Love songs centered on affection, excitement, or longing between partners
+   - Sweet, romantic atmosphere — dates, night drives, confessions
+   - The emotion is clearly about romance between two people
+
+5. "공연을 준비할 때"  (Preparing for a performance / showstopper)
+   - Songs that showcase vocal ability: high notes, runs, dramatic delivery
+   - Ideal for impressing an audience at karaoke or on stage
+   - Dramatic arc; the kind of song that earns applause
+
+6. "신나게 놀고 싶을 때"  (Party / dance mode)
+   - Trendy dance-pop, EDM, or hip-hop with a hard beat for clubs or mid-party hype
+   - High-energy songs that keep the party going — does NOT have to be universally known
+   - Newer or niche tracks are fine here; energy and beat matter most
+
+7. "감성에 젖고 싶을 때"  (Emotional / melancholic mood)
+   - Quiet ballads about sadness, longing, loneliness, or finding comfort
+   - Best listened to alone late at night or when feeling reflective
+   - NOT romance-focused — the core emotion is grief, nostalgia, or solace
+
+8. "엔딩곡이 필요할 때"  (The grand finale / closing anthem)
+   - A universally beloved classic hit that EVERYONE at the party already knows by heart
+   - Used to close a karaoke session or party with a massive group sing-along (떼창)
+   - Think: concert encore, festival finale — impactful, triumphant, crowd-wide
+   - The longer the song has been loved and the more widely it is known, the stronger the fit
+   - Must feel like a grand, triumphant GROUP ending, NOT a quiet wind-down
+
+=== How to distinguish similar labels ===
+- "신나게" vs "엔딩곡": "신나게" = trendy mid-party banger (niche OK); "엔딩곡" = timeless anthem everyone sings together to close the night
+- "연인" vs "감성": "연인" = romance/love theme; "감성" = sadness/loneliness/comfort theme
+- "회식" vs "친구": "회식" = older adult crowd (30s+); "친구" = younger crowd (teens~20s)
+- "엔딩곡" vs "공연": "엔딩곡" = everyone sings together; "공연" = one person shows off their skills
+
+=== Golden Examples ===
+
+Input: Title: 사랑의 배터리 | Artist: 박상민 | Genre: 발라드
+Output: {"label": "회식하며 즐길 때", "reason": "30-40대 직장인 회식 단골 노래로 누구나 따라부를 수 있는 국민 발라드입니다."}
+
+Input: Title: 가족사진 | Artist: 성시경 | Genre: 발라드
+Output: {"label": "가족과 함께할 때", "reason": "가족을 주제로 한 따뜻하고 건전한 노래로 세대를 초월해 함께 들을 수 있습니다."}
+
+Input: Title: FIRE | Artist: BTS | Genre: 힙합
+Output: {"label": "친구랑 놀 때", "reason": "10-20대가 친구들과 어울릴 때 신나게 즐길 수 있는 아이돌 힙합입니다."}
+
+Input: Title: 사랑을 했다 | Artist: IKON | Genre: 발라드 힙합
+Output: {"label": "연인과 함께할 때", "reason": "연인에 대한 사랑과 그리움을 담은 달콤한 러브송입니다."}
+
+Input: Title: 거짓말이야 | Artist: 임창정 | Genre: 발라드
+Output: {"label": "공연을 준비할 때", "reason": "고음과 감정 표현이 필요한 노래로 노래방에서 실력을 보여주기에 적합합니다."}
+
+Input: Title: TOMBOY | Artist: (여자)아이들 | Genre: 댄스
+Output: {"label": "신나게 놀고 싶을 때", "reason": "강한 비트의 트렌디한 걸그룹 댄스곡으로 파티나 클럽에서 즐기기 좋습니다."}
+
+Input: Title: 야생화 | Artist: 박효신 | Genre: 발라드
+Output: {"label": "감성에 젖고 싶을 때", "reason": "혼자 듣기 좋은 서정적인 발라드로 그리움과 위로의 감성을 전달합니다."}
+
+Input: Title: 아파트 | Artist: 로이킨 & 핑클 | Genre: 댄스
+Output: {"label": "엔딩곡이 필요할 때", "reason": "노래방 마지막 곡으로 모두가 함께 떼창하는 국민 댄스곡입니다."}
+
+=== Rules ===
+- Choose EXACTLY ONE label from the 8 options.
+- Copy the label name EXACTLY as written above (Korean text, no changes).
+- Respond ONLY in this JSON format:
+{"label": "<exact label name>", "reason": "<1-2 sentences in Korean explaining the choice>"}
+"""
+
+
+class SituationClassifier:
+    def __init__(self, api_key: str, model: str = "gpt-4o-mini"):
+        self._client = AsyncOpenAI(api_key=api_key)
+        self.model = model
+
+    async def classify(
+        self,
+        title: str,
+        artist: str,
+        genre: Optional[str],
+        max_retries: int = 3,
+    ) -> dict:
+        """노래 정보를 받아 상황 라벨 분류 결과 반환.
+
+        Returns:
+            {"label": "...", "reason": "..."}
+        Raises:
+            ValueError: 라벨이 유효하지 않거나 JSON 파싱 실패
+            APIError:   재시도 초과 시
+        """
+        user_content = f"Title: {title}\nArtist: {artist}\nGenre: {genre or 'unknown'}"
+
+        last_exc: Exception | None = None
+        response = None
+
+        for attempt in range(max_retries):
+            try:
+                response = await self._client.chat.completions.create(
+                    model=self.model,
+                    temperature=0,
+                    response_format={"type": "json_object"},
+                    messages=[
+                        {"role": "system", "content": _SYSTEM_PROMPT},
+                        {"role": "user", "content": user_content},
+                    ],
+                )
+                break
+            except RateLimitError as e:
+                wait = 2 ** attempt * 5  # 5s → 10s → 20s
+                logger.warning("Rate limit. %ds 후 재시도 (%d/%d)...", wait, attempt + 1, max_retries)
+                await asyncio.sleep(wait)
+                last_exc = e
+            except APIError as e:
+                logger.warning("OpenAI API 오류: %s. 재시도 (%d/%d)...", e, attempt + 1, max_retries)
+                await asyncio.sleep(2 ** attempt)
+                last_exc = e
+        else:
+            raise last_exc
+
+        raw = response.choices[0].message.content
+        try:
+            result = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"JSON 파싱 실패: {raw}") from e
+
+        label = result.get("label", "")
+        if label not in SITUATION_LABELS:
+            raise ValueError(f"유효하지 않은 라벨: '{label}'")
+
+        return {"label": label, "reason": result.get("reason", "")}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,6 @@ pyyaml==6.0.2
 
 # AWS
 boto3
+
+# OpenAI
+openai>=1.0.0

--- a/backend/scripts/tag_songs.py
+++ b/backend/scripts/tag_songs.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""songs 테이블의 곡을 8개 상황 라벨로 분류하여 tags JSONB에 저장하는 배치 스크립트.
+
+사용법:
+    cd backend
+    python scripts/tag_songs.py [옵션]
+
+옵션:
+    --batch-size    한 번에 처리할 곡 수 (기본: 20)
+    --sleep-ms      OpenAI 호출 사이 대기 시간 ms (기본: 200)
+    --limit         최대 처리 곡 수, 0=전체 (기본: 0)
+    --model         OpenAI 모델명 (기본: gpt-4o-mini)
+    --dry-run       DB 저장 없이 분류 결과만 출력 (최대 3곡 샘플)
+
+환경 변수:
+    OPENAI_API_KEY  (필수, .env 또는 환경 변수)
+    DATABASE_URL    (필수, .env)
+"""
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND_DIR))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="노래 상황 라벨 분류 배치")
+    parser.add_argument("--batch-size", type=int, default=20, help="배치 크기 (기본: 20)")
+    parser.add_argument("--sleep-ms", type=int, default=200, help="OpenAI 호출 간격 ms (기본: 200)")
+    parser.add_argument("--limit", type=int, default=0, help="최대 처리 수, 0=전체 (기본: 0)")
+    parser.add_argument("--model", type=str, default="gpt-4o-mini", help="OpenAI 모델 (기본: gpt-4o-mini)")
+    parser.add_argument("--dry-run", action="store_true", help="DB 저장 없이 최대 3곡 결과만 출력")
+    return parser.parse_args()
+
+
+async def main(args: argparse.Namespace) -> None:
+    from app.config import settings
+    from app.database import AsyncSessionLocal
+    from app.services.song_tag_service import SongTagService
+    from app.utils.openai_client import SituationClassifier
+
+    if not settings.OPENAI_API_KEY:
+        logger.error("OPENAI_API_KEY가 설정되지 않았습니다. .env를 확인하세요.")
+        sys.exit(1)
+
+    classifier = SituationClassifier(api_key=settings.OPENAI_API_KEY, model=args.model)
+
+    if args.dry_run:
+        await _dry_run(classifier)
+        return
+
+    async with AsyncSessionLocal() as db:
+        service = SongTagService(classifier=classifier, db=db)
+        logger.info(
+            "시작 | model=%s  batch=%d  sleep=%dms  limit=%s",
+            args.model, args.batch_size, args.sleep_ms,
+            args.limit if args.limit else "전체",
+        )
+        result = await service.run_all(
+            batch_size=args.batch_size,
+            sleep_ms=args.sleep_ms,
+            limit=args.limit,
+        )
+
+    logger.info("=" * 50)
+    logger.info("완료 | 성공: %d  실패: %d", result.success, result.failed)
+    if result.errors:
+        logger.warning("실패 목록:")
+        for err in result.errors:
+            logger.warning("  %s", err)
+
+
+async def _dry_run(classifier: "SituationClassifier") -> None:
+    """DB 없이 미태깅 3곡 샘플로 OpenAI 응답만 확인"""
+    from app.database import AsyncSessionLocal
+    from app.repositories.song_repository import SongRepository
+
+    logger.info("[DRY-RUN] DB 저장 없이 최대 3곡 분류 결과만 출력")
+    async with AsyncSessionLocal() as db:
+        repo = SongRepository(db)
+        songs = await repo.get_untagged_batch(batch_size=3, offset=0)
+
+    if not songs:
+        logger.info("처리할 곡이 없습니다 (모두 이미 태깅됨).")
+        return
+
+    for song in songs:
+        try:
+            result = await classifier.classify(song.title, song.artist, song.genre)
+            logger.info(
+                "[DRY-RUN] %s - %s\n  → label : %s\n  → reason: %s",
+                song.artist, song.title, result["label"], result["reason"],
+            )
+        except Exception as e:
+            logger.warning("[DRY-RUN] 실패: %s - %s: %s", song.artist, song.title, e)
+
+
+if __name__ == "__main__":
+    asyncio.run(main(parse_args()))


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #108 


## 📤 Tasks
- `songs` 테이블의 미분류 곡을 조회해 상황 라벨을 분류하는 배치/스크립트 기능을 추가했습니다.
- OpenAI API를 이용해 `title`, `artist`, `genre` 기반으로 8개 상황 라벨 중 1개를 JSON 형식으로 분류하도록 구현했습니다.
- 분류 결과를 `tags` 컬럼에 `situationLabel`, `situationReason` 형태로 merge 저장하도록 반영했습니다.
- 이미 라벨링된 곡은 제외하여 중복 호출을 방지하도록 처리했습니다.
- 배치 실행 시 로깅, 예외 처리, 간단한 재시도 로직을 추가했습니다.
- dry-run 옵션으로 DB 저장 없이 샘플 곡 결과를 확인할 수 있도록 구성했습니다.

<br/>

## 📸 Screenshot
<!-- 관련 스크린샷을 첨부해주세요. -->
<img width="1186" height="595" alt="image" src="https://github.com/user-attachments/assets/62e4d6da-80e8-428d-b2ec-9c61153e3506" />

<br/>

## 💌 To Reviewer
- `tags` 컬럼 merge 방식이 기존 프로젝트 JSON 처리 방식과 잘 맞는지 중점적으로 봐주시면 감사하겠습니다.
- 배치 실행 위치를 스크립트 방식으로 두었는데, 추후 admin/dev endpoint로 분리하는 것이 더 적절한지도 의견 부탁드립니다.

<br/>
