### PR TITLE
Feat(server): 마이페이지 프로필 수정 및 가수/곡 차단 API 리팩토링

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,6 @@ from app.models.song import Song
 from app.models.library import Folder, WishlistItem
 from app.models.archive import Archive
 from app.models.recommendation import Recommendation
-from app.models.singer import Singer, BlockedSinger, FavoriteSinger
+from app.models.singer import Singer, BlockedSinger, BlockedSong, FavoriteSinger
 
-__all__ = ["User", "RefreshToken", "Song", "Folder", "WishlistItem", "Archive", "Recommendation", "Singer", "BlockedSinger", "FavoriteSinger"]
+__all__ = ["User", "RefreshToken", "Song", "Folder", "WishlistItem", "Archive", "Recommendation", "Singer", "BlockedSinger", "BlockedSong", "FavoriteSinger"]

--- a/backend/app/models/singer.py
+++ b/backend/app/models/singer.py
@@ -1,4 +1,4 @@
-"""Singer & BlockedSinger & FavoriteSinger 모델"""
+"""Singer & BlockedSinger & BlockedSong & FavoriteSinger 모델"""
 from sqlalchemy import Column, String, Integer, DateTime, ForeignKey, Uuid, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
@@ -35,6 +35,19 @@ class BlockedSinger(Base):
 
     __table_args__ = (
         UniqueConstraint("user_id", "singer_id", name="uq_user_singer_block"),
+    )
+
+
+class BlockedSong(Base):
+    __tablename__ = "blocked_songs"
+
+    block_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Uuid, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    song_id = Column(Uuid, ForeignKey("songs.id", ondelete="CASCADE"), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "song_id", name="uq_user_song_block"),
     )
 
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -14,13 +14,17 @@ class User(Base):
     nickname = Column(String, nullable=False)
     email = Column(String, unique=True, index=True, nullable=True)
     profile_img = Column(String, nullable=True)
+    bio = Column(String(200), nullable=True)
 
-    # Auth
-    provider = Column(String, nullable=False)       # kakao, naver
+    # Auth - primary provider
+    provider = Column(String, nullable=False)       # "kakao" | "naver"
     provider_id = Column(String, nullable=False)
 
-    # JSON - 보컬 분석 캐시 (마이페이지 성능)
+    # SNS 추가 연동 ID (primary와 다른 provider)
+    kakao_id = Column(String, unique=True, nullable=True)
+    naver_id = Column(String, unique=True, nullable=True)
 
+    # JSON - 보컬 분석 캐시 (마이페이지 성능)
     vocal_summary_cache = Column(JSON, nullable=True)
 
     # JSON - 설정 통합

--- a/backend/app/routers/library.py
+++ b/backend/app/routers/library.py
@@ -2,7 +2,7 @@
 from uuid import UUID
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status  # noqa: F401
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, delete
 from sqlalchemy.orm import selectinload
@@ -12,14 +12,11 @@ from app.dependencies.auth import get_current_user
 from app.models.user import User
 from app.models.library import Folder, WishlistItem
 from app.models.archive import Archive
-from app.models.singer import BlockedSinger
 from app.schemas.library import (
     FolderCreate, FolderResponse,
     WishlistItemCreate, WishlistItemResponse,
 )
 from app.schemas.archive import ArchiveCreate, ArchiveUpdate, ArchiveResponse
-from app.schemas.singer import BlockSingerRequest, BlockSingerResponse, BlockedSingerItem
-from app.services.singer_service import SingerService
 
 router = APIRouter(prefix="/api/v1/library", tags=["Library"])
 
@@ -292,67 +289,3 @@ async def delete_history(
     await db.delete(archive)
 
 
-# ═══════════════════════════════════════════════════
-# Blocked endpoints (가수/곡 차단)
-# ═══════════════════════════════════════════════════
-
-@router.post("/blocked", response_model=BlockSingerResponse, status_code=status.HTTP_201_CREATED)
-async def block_target(
-    body: BlockSingerRequest,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-):
-    """가수 또는 곡 차단 등록 (type: ARTIST | SONG)"""
-    if body.type == "ARTIST":
-        service = SingerService(db)
-        blocked = await service.block_singer(
-            user_id=current_user.id,
-            singer_id=int(body.target_id),
-        )
-        return BlockSingerResponse(
-            id=f"block_{blocked.block_id}",
-            created_at=blocked.created_at,
-        )
-
-    raise HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail={"code": "UNSUPPORTED_TYPE", "message": "지원하지 않는 차단 type입니다."},
-    )
-
-
-@router.get("/blocked", response_model=List[BlockedSingerItem])
-async def get_blocked_list(
-    type: str = Query("ARTIST", description="차단 유형 (ARTIST)"),
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-):
-    """차단 목록 조회 (현재 ARTIST 타입만 지원)"""
-    if type == "ARTIST":
-        service = SingerService(db)
-        blocked_list = await service.get_blocked_singers(user_id=current_user.id)
-        return [
-            BlockedSingerItem(
-                block_id=b.block_id,
-                singer_id=b.singer_id,
-                name=b.singer.name,
-                photo_url=b.singer.photo_url,
-                created_at=b.created_at,
-            )
-            for b in blocked_list
-        ]
-
-    raise HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail={"code": "UNSUPPORTED_TYPE", "message": "지원하지 않는 차단 type입니다."},
-    )
-
-
-@router.delete("/blocked/{block_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def unblock_target(
-    block_id: int,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-):
-    """차단 해제 - 본인 차단 건만 삭제 가능 (타인 접근 시 403)"""
-    service = SingerService(db)
-    await service.unblock_singer(user_id=current_user.id, block_id=block_id)

--- a/backend/app/routers/user.py
+++ b/backend/app/routers/user.py
@@ -1,12 +1,27 @@
 """유저 라우터"""
-from fastapi import APIRouter, Depends, HTTPException, status
+import time
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.dependencies.auth import get_current_user
 from app.models.user import User
-from app.schemas.user import UserResponse, UserUpdateRequest, SettingsUpdateRequest
+from app.schemas.singer import (
+    BlockSingerRequest, BlockedSingerItem, BlockedSingersListResponse,
+    BlockSongRequest, BlockedSongItem, BlockedSongsListResponse,
+    SingerInfo,
+)
+from app.schemas.user import UserMeResponse, UserResponse, UserUpdateRequest, SettingsUpdateRequest
 from app.services.user_service import UserService
+from app.utils.aws import upload_image_to_s3
+
+_ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp"}
+_MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5 MB
+_MAX_NICKNAME_LEN = 20
+_MAX_BIO_LEN = 200
 
 router = APIRouter(prefix="/api/v1/users", tags=["Users"])
 
@@ -16,24 +31,270 @@ router = APIRouter(prefix="/api/v1/users", tags=["Users"])
 # ─────────────────────────────────────
 @router.get(
     "/me",
-    response_model=UserResponse,
-    summary="내 정보 조회",
-    description="현재 로그인된 사용자의 정보를 반환합니다. "
-    "캐시된 보컬 분석 정보(vocal_summary)도 포함됩니다.",
+    response_model=UserMeResponse,
+    summary="내 정보 조회 (마이페이지)",
+    description="선호 가수, 차단 가수, 연동된 SNS 계정 목록을 포함한 전체 프로필을 반환합니다.",
 )
 async def get_me(
     current_user: User = Depends(get_current_user),
-) -> UserResponse:
-    return UserResponse.model_validate(current_user)
+    db: AsyncSession = Depends(get_db),
+) -> UserMeResponse:
+    service = UserService(db)
+    profile = await service.get_full_profile(current_user.id)
+    return UserMeResponse(
+        **UserResponse.model_validate(profile.user).model_dump(),
+        favorite_singers=[
+            SingerInfo(singer_id=s.singer_id, name=s.name, photo_url=s.photo_url)
+            for s in profile.favorite_singers
+        ],
+        blocked_singers=[
+            SingerInfo(singer_id=s.singer_id, name=s.name, photo_url=s.photo_url)
+            for s in profile.blocked_singers
+        ],
+        blocked_songs=[BlockedSongItem(**item) for item in profile.blocked_songs],
+        linked_providers=service.get_linked_providers(profile.user),
+    )
 
 
 # ─────────────────────────────────────
-# PATCH /api/v1/users/me
+# PATCH /api/v1/users/me/profile
+# ─────────────────────────────────────
+@router.patch(
+    "/me/profile",
+    response_model=UserResponse,
+    summary="마이페이지 프로필 수정",
+    description=(
+        "`multipart/form-data`로 전송. "
+        "`nickname`, `bio`, `profile_image` 중 하나 이상 포함해야 합니다. "
+        "`bio`를 빈 문자열로 보내면 소개글이 삭제됩니다."
+    ),
+)
+async def update_mypage_profile(
+    nickname: Optional[str] = Form(None, description="닉네임 (1~20자)"),
+    bio: Optional[str] = Form(None, description="소개글 (최대 200자, 빈 문자열 = 삭제)"),
+    profile_image: Optional[UploadFile] = File(None, description="프로필 사진 (jpeg/png/webp, 최대 5MB)"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> UserResponse:
+    nickname_provided = nickname is not None
+    bio_provided = bio is not None
+    image_provided = profile_image is not None and bool(profile_image.filename)
+
+    if not nickname_provided and not bio_provided and not image_provided:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "NOTHING_TO_UPDATE", "message": "수정할 항목이 없습니다."},
+        )
+
+    # ── 닉네임 검증 ──────────────────────────────────
+    if nickname_provided:
+        stripped_nickname = nickname.strip() if nickname else ""
+        if not stripped_nickname:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"code": "INVALID_NICKNAME", "message": "닉네임은 공백만으로 구성될 수 없습니다."},
+            )
+        if len(stripped_nickname) > _MAX_NICKNAME_LEN:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"code": "NICKNAME_TOO_LONG", "message": f"닉네임은 최대 {_MAX_NICKNAME_LEN}자입니다."},
+            )
+
+    # ── 소개글 검증 ───────────────────────────────────
+    if bio_provided and bio and len(bio) > _MAX_BIO_LEN:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"code": "BIO_TOO_LONG", "message": f"소개글은 최대 {_MAX_BIO_LEN}자입니다."},
+        )
+
+    # ── 프로필 사진 업로드 ────────────────────────────
+    profile_img_url: Optional[str] = None
+    if image_provided:
+        content_type = profile_image.content_type or ""
+        if content_type not in _ALLOWED_IMAGE_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                detail={"code": "INVALID_IMAGE_TYPE", "message": "jpeg, png, webp 이미지만 업로드 가능합니다."},
+            )
+        file_bytes = await profile_image.read()
+        if len(file_bytes) > _MAX_IMAGE_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail={"code": "IMAGE_TOO_LARGE", "message": "이미지 크기는 5MB 이하여야 합니다."},
+            )
+        ext = content_type.split("/")[-1]
+        key = f"profiles/{current_user.id}/{int(time.time())}.{ext}"
+        url = upload_image_to_s3(file_bytes, key, content_type)
+        if url is None:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail={"code": "S3_UPLOAD_FAILED", "message": "프로필 사진 업로드에 실패했습니다."},
+            )
+        profile_img_url = url
+
+    # ── 서비스 레이어 ─────────────────────────────────
+    service = UserService(db)
+    updated = await service.update_mypage_profile(
+        user_id=current_user.id,
+        nickname=nickname,
+        bio=bio,
+        profile_img_url=profile_img_url,
+        _nickname_provided=nickname_provided,
+        _bio_provided=bio_provided,
+    )
+    return UserResponse.model_validate(updated)
+
+
+# ─────────────────────────────────────
+# DELETE /api/v1/users/me/linked-accounts/{provider}
+# ─────────────────────────────────────
+@router.delete(
+    "/me/linked-accounts/{provider}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="SNS 계정 연동 해제",
+    description="연동된 카카오 또는 네이버 계정을 해제합니다. 기본 로그인 계정은 해제할 수 없습니다.",
+)
+async def unlink_account(
+    provider: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    if provider not in {"kakao", "naver"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "INVALID_PROVIDER", "message": "provider는 kakao 또는 naver이어야 합니다."},
+        )
+    if current_user.provider == provider:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "PRIMARY_PROVIDER", "message": "기본 로그인 계정은 연동 해제할 수 없습니다."},
+        )
+    service = UserService(db)
+    await service.unlink_account(user_id=current_user.id, provider=provider)
+
+
+# ─────────────────────────────────────
+# GET /api/v1/users/me/blocked-singers
+# ─────────────────────────────────────
+@router.get(
+    "/me/blocked-singers",
+    response_model=BlockedSingersListResponse,
+    summary="차단한 가수 목록 조회",
+)
+async def get_blocked_singers(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> BlockedSingersListResponse:
+    service = UserService(db)
+    items = await service.get_blocked_singers(current_user.id)
+    return BlockedSingersListResponse(
+        blocked_singers=[BlockedSingerItem(**item) for item in items]
+    )
+
+
+# ─────────────────────────────────────
+# POST /api/v1/users/me/blocked-singers
+# ─────────────────────────────────────
+@router.post(
+    "/me/blocked-singers",
+    response_model=BlockedSingerItem,
+    status_code=status.HTTP_201_CREATED,
+    summary="가수 차단",
+)
+async def block_singer(
+    body: BlockSingerRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> BlockedSingerItem:
+    service = UserService(db)
+    item = await service.block_singer(current_user.id, body.singer_id)
+    await db.commit()
+    return BlockedSingerItem(**item)
+
+
+# ─────────────────────────────────────
+# DELETE /api/v1/users/me/blocked-singers/{singer_id}
+# ─────────────────────────────────────
+@router.delete(
+    "/me/blocked-singers/{singer_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="가수 차단 해제",
+)
+async def unblock_singer(
+    singer_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    service = UserService(db)
+    await service.unblock_singer(current_user.id, singer_id)
+    await db.commit()
+
+
+# ─────────────────────────────────────
+# GET /api/v1/users/me/blocked-songs
+# ─────────────────────────────────────
+@router.get(
+    "/me/blocked-songs",
+    response_model=BlockedSongsListResponse,
+    summary="차단한 곡 목록 조회",
+)
+async def get_blocked_songs(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> BlockedSongsListResponse:
+    service = UserService(db)
+    items = await service.get_blocked_songs(current_user.id)
+    return BlockedSongsListResponse(
+        blocked_songs=[BlockedSongItem(**item) for item in items]
+    )
+
+
+# ─────────────────────────────────────
+# POST /api/v1/users/me/blocked-songs
+# ─────────────────────────────────────
+@router.post(
+    "/me/blocked-songs",
+    response_model=BlockedSongItem,
+    status_code=status.HTTP_201_CREATED,
+    summary="곡 차단",
+)
+async def block_song(
+    body: BlockSongRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> BlockedSongItem:
+    service = UserService(db)
+    item = await service.block_song(current_user.id, body.song_id)
+    await db.commit()
+    return BlockedSongItem(**item)
+
+
+# ─────────────────────────────────────
+# DELETE /api/v1/users/me/blocked-songs/{song_id}
+# ─────────────────────────────────────
+@router.delete(
+    "/me/blocked-songs/{song_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="곡 차단 해제",
+)
+async def unblock_song(
+    song_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    service = UserService(db)
+    await service.unblock_song(current_user.id, song_id)
+    await db.commit()
+
+
+# ─────────────────────────────────────
+# PATCH /api/v1/users/me  (기존 유지 - 닉네임 JSON 전용)
 # ─────────────────────────────────────
 @router.patch(
     "/me",
     response_model=UserResponse,
-    summary="프로필 수정",
+    summary="닉네임 수정 (JSON)",
+    description="닉네임만 JSON으로 빠르게 수정할 때 사용합니다. 사진/소개글은 `/me/profile`을 사용하세요.",
 )
 async def update_profile(
     body: UserUpdateRequest,
@@ -46,7 +307,6 @@ async def update_profile(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="수정할 항목이 없습니다.",
         )
-
     service = UserService(db)
     updated = await service.update_profile(
         user_id=current_user.id,
@@ -75,7 +335,6 @@ async def update_settings(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="수정할 항목이 없습니다.",
         )
-
     service = UserService(db)
     return await service.update_settings(
         user_id=current_user.id,

--- a/backend/app/schemas/singer.py
+++ b/backend/app/schemas/singer.py
@@ -2,6 +2,7 @@
 from pydantic import BaseModel, field_validator
 from typing import List, Optional
 from datetime import datetime
+from uuid import UUID
 
 
 # ── Random Singers ───────────────────────────────────
@@ -44,8 +45,7 @@ class FavoriteSingersSelectResponse(BaseModel):
 # ── Blocked Singer ───────────────────────────────────
 
 class BlockSingerRequest(BaseModel):
-    type: str        # "ARTIST" | "SONG"
-    target_id: str   # singer_id (문자열로 수신)
+    singer_id: int
 
 
 class BlockSingerResponse(BaseModel):
@@ -61,3 +61,28 @@ class BlockedSingerItem(BaseModel):
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class BlockedSingersListResponse(BaseModel):
+    blocked_singers: List[BlockedSingerItem]
+
+
+# ── Blocked Song ──────────────────────────────────────
+
+class BlockSongRequest(BaseModel):
+    song_id: UUID
+
+
+class BlockedSongItem(BaseModel):
+    block_id: int
+    song_id: UUID
+    title: str
+    artist: str
+    album_cover: Optional[str] = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BlockedSongsListResponse(BaseModel):
+    blocked_songs: List[BlockedSongItem]

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,16 +1,19 @@
 """사용자 관련 스키마"""
 from pydantic import BaseModel, Field
-from typing import Optional, Dict, Any
+from typing import List, Optional, Dict, Any
 from datetime import datetime
 from uuid import UUID
 
+from app.schemas.singer import BlockedSongItem, SingerInfo
+
 
 class UserResponse(BaseModel):
-    """GET /users/me 응답 - 보컬 캐시 포함"""
+    """기본 유저 응답 - 인증/수정 결과 반환용"""
     id: UUID
     nickname: str
     email: Optional[str] = None
     profile_img: Optional[str] = None
+    bio: Optional[str] = None
     provider: str
     vocal_summary: Optional[Dict[str, Any]] = Field(
         None, validation_alias="vocal_summary_cache"
@@ -20,6 +23,14 @@ class UserResponse(BaseModel):
     updated_at: Optional[datetime] = None
 
     model_config = {"from_attributes": True, "populate_by_name": True}
+
+
+class UserMeResponse(UserResponse):
+    """GET /users/me 전용 - 선호 가수, 차단 가수, 차단 곡, 연동 SNS 포함"""
+    favorite_singers: List[SingerInfo] = []
+    blocked_singers: List[SingerInfo] = []
+    blocked_songs: List[BlockedSongItem] = []
+    linked_providers: List[str] = []   # e.g. ["kakao", "naver"]
 
 
 class UserUpdateRequest(BaseModel):

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,10 +1,25 @@
-"""유저 서비스 - 프로필 조회/수정, 설정 JSONB 머지"""
+"""유저 서비스 - 프로필 조회/수정, 설정 JSONB 머지, SNS 연동"""
 import uuid
+from dataclasses import dataclass, field
+from typing import List
 
+from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sqlalchemy.exc import IntegrityError
+
+from app.models.singer import BlockedSinger, BlockedSong, FavoriteSinger, Singer
+from app.models.song import Song
 from app.models.user import User
+
+
+@dataclass
+class FullProfile:
+    user: User
+    favorite_singers: List[Singer] = field(default_factory=list)
+    blocked_singers: List[Singer] = field(default_factory=list)
+    blocked_songs: List[dict] = field(default_factory=list)
 
 
 class UserService:
@@ -18,6 +33,56 @@ class UserService:
         if not user:
             raise ValueError("사용자를 찾을 수 없습니다.")
         return user
+
+    async def get_full_profile(self, user_id: uuid.UUID) -> FullProfile:
+        """마이페이지 전용: 유저 정보 + 선호 가수 + 차단 가수 한 번에 조회"""
+        user = await self.get_user(user_id)
+
+        fav_result = await self.db.execute(
+            select(Singer)
+            .join(FavoriteSinger, FavoriteSinger.singer_id == Singer.singer_id)
+            .where(FavoriteSinger.user_id == user_id)
+            .order_by(Singer.name)
+        )
+        blocked_result = await self.db.execute(
+            select(Singer)
+            .join(BlockedSinger, BlockedSinger.singer_id == Singer.singer_id)
+            .where(BlockedSinger.user_id == user_id)
+            .order_by(Singer.name)
+        )
+        blocked_songs_result = await self.db.execute(
+            select(BlockedSong, Song)
+            .join(Song, Song.id == BlockedSong.song_id)
+            .where(BlockedSong.user_id == user_id)
+            .order_by(BlockedSong.created_at.desc())
+        )
+        blocked_songs = [
+            {
+                "block_id": bs.block_id,
+                "song_id": song.id,
+                "title": song.title,
+                "artist": song.artist,
+                "album_cover": song.album_cover,
+                "created_at": bs.created_at,
+            }
+            for bs, song in blocked_songs_result.all()
+        ]
+
+        return FullProfile(
+            user=user,
+            favorite_singers=list(fav_result.scalars().all()),
+            blocked_singers=list(blocked_result.scalars().all()),
+            blocked_songs=blocked_songs,
+        )
+
+    def get_linked_providers(self, user: User) -> List[str]:
+        """연동된 SNS 프로바이더 목록 반환 (primary 포함)"""
+        providers = [user.provider]
+        if user.provider != "kakao" and user.kakao_id:
+            providers.append("kakao")
+        if user.provider != "naver" and user.naver_id:
+            providers.append("naver")
+        return providers
 
     async def update_profile(
         self,
@@ -47,15 +112,220 @@ class UserService:
         await self.db.flush()
         return user
 
+    async def update_mypage_profile(
+        self,
+        user_id: uuid.UUID,
+        nickname: str | None,
+        bio: str | None,
+        profile_img_url: str | None = None,
+        _nickname_provided: bool = False,
+        _bio_provided: bool = False,
+    ) -> User:
+        """마이페이지 프로필 수정: 닉네임 + 소개글 + 프로필 사진 부분 업데이트"""
+        user = await self.get_user(user_id)
+        if _nickname_provided:
+            stripped = nickname.strip() if nickname else ""
+            if not stripped:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail={"code": "INVALID_NICKNAME", "message": "닉네임은 공백만으로 구성될 수 없습니다."},
+                )
+            user.nickname = stripped
+        if profile_img_url is not None:
+            user.profile_img = profile_img_url
+        if _bio_provided:
+            user.bio = bio.strip() if bio and bio.strip() else None
+        await self.db.flush()
+        return user
+
+    # ─── SNS 연동 관리 ────────────────────────────────
+
+    async def link_account(
+        self, user_id: uuid.UUID, provider: str, provider_id: str
+    ) -> User:
+        """SNS 계정 추가 연동 - users 테이블 kakao_id / naver_id 업데이트"""
+        user = await self.get_user(user_id)
+
+        if user.provider == provider:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"code": "PRIMARY_PROVIDER", "message": f"{provider}는 이미 기본 로그인 계정입니다."},
+            )
+
+        id_col = f"{provider}_id"
+        if getattr(user, id_col) is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": "ALREADY_LINKED", "message": f"이미 {provider} 계정이 연동되어 있습니다."},
+            )
+
+        # 해당 provider_id가 다른 유저에게 사용 중인지 확인
+        conflict = await self.db.execute(
+            select(User).where(getattr(User, id_col) == provider_id)
+        )
+        if conflict.scalar_one_or_none():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": "PROVIDER_ID_TAKEN", "message": "해당 SNS 계정은 이미 다른 유저에게 연동되어 있습니다."},
+            )
+
+        setattr(user, id_col, provider_id)
+        await self.db.flush()
+        return user
+
+    async def unlink_account(self, user_id: uuid.UUID, provider: str) -> User:
+        """SNS 계정 연동 해제"""
+        user = await self.get_user(user_id)
+        id_col = f"{provider}_id"
+
+        if getattr(user, id_col) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"code": "LINKED_ACCOUNT_NOT_FOUND", "message": f"연동된 {provider} 계정이 없습니다."},
+            )
+
+        setattr(user, id_col, None)
+        await self.db.flush()
+        return user
+
+    # ─── 가수 차단 관리 ───────────────────────────────
+
+    async def get_blocked_singers(self, user_id: uuid.UUID) -> list[dict]:
+        """차단한 가수 목록 조회 (block_id, singer_id, name, photo_url, created_at)"""
+        result = await self.db.execute(
+            select(BlockedSinger, Singer)
+            .join(Singer, Singer.singer_id == BlockedSinger.singer_id)
+            .where(BlockedSinger.user_id == user_id)
+            .order_by(BlockedSinger.created_at.desc())
+        )
+        return [
+            {
+                "block_id": blocked.block_id,
+                "singer_id": singer.singer_id,
+                "name": singer.name,
+                "photo_url": singer.photo_url,
+                "created_at": blocked.created_at,
+            }
+            for blocked, singer in result.all()
+        ]
+
+    async def block_singer(self, user_id: uuid.UUID, singer_id: int) -> dict:
+        """가수 차단. 이미 차단된 경우 409, 없는 가수 404."""
+        singer = await self.db.get(Singer, singer_id)
+        if not singer:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"code": "SINGER_NOT_FOUND", "message": "존재하지 않는 가수입니다."},
+            )
+
+        record = BlockedSinger(user_id=user_id, singer_id=singer_id)
+        self.db.add(record)
+        try:
+            await self.db.flush()
+        except IntegrityError:
+            await self.db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": "ALREADY_BLOCKED", "message": "이미 차단한 가수입니다."},
+            )
+        return {
+            "block_id": record.block_id,
+            "singer_id": singer.singer_id,
+            "name": singer.name,
+            "photo_url": singer.photo_url,
+            "created_at": record.created_at,
+        }
+
+    async def unblock_singer(self, user_id: uuid.UUID, singer_id: int) -> None:
+        """가수 차단 해제. 차단 내역이 없으면 404."""
+        result = await self.db.execute(
+            select(BlockedSinger).where(
+                BlockedSinger.user_id == user_id,
+                BlockedSinger.singer_id == singer_id,
+            )
+        )
+        record = result.scalar_one_or_none()
+        if not record:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"code": "BLOCK_NOT_FOUND", "message": "차단 내역이 없습니다."},
+            )
+        await self.db.delete(record)
+        await self.db.flush()
+
+    # ─── 곡 차단 관리 ─────────────────────────────────
+
+    async def get_blocked_songs(self, user_id: uuid.UUID) -> list[dict]:
+        """차단한 곡 목록 조회 (block_id, song_id, title, artist, album_cover, created_at)"""
+        result = await self.db.execute(
+            select(BlockedSong, Song)
+            .join(Song, Song.id == BlockedSong.song_id)
+            .where(BlockedSong.user_id == user_id)
+            .order_by(BlockedSong.created_at.desc())
+        )
+        return [
+            {
+                "block_id": blocked.block_id,
+                "song_id": song.id,
+                "title": song.title,
+                "artist": song.artist,
+                "album_cover": song.album_cover,
+                "created_at": blocked.created_at,
+            }
+            for blocked, song in result.all()
+        ]
+
+    async def block_song(self, user_id: uuid.UUID, song_id: uuid.UUID) -> dict:
+        """곡 차단. 없는 곡이면 404, 이미 차단이면 409."""
+        song = await self.db.get(Song, song_id)
+        if not song:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"code": "SONG_NOT_FOUND", "message": "존재하지 않는 곡입니다."},
+            )
+
+        record = BlockedSong(user_id=user_id, song_id=song_id)
+        self.db.add(record)
+        try:
+            await self.db.flush()
+        except IntegrityError:
+            await self.db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": "ALREADY_BLOCKED", "message": "이미 차단한 곡입니다."},
+            )
+        return {
+            "block_id": record.block_id,
+            "song_id": song.id,
+            "title": song.title,
+            "artist": song.artist,
+            "album_cover": song.album_cover,
+            "created_at": record.created_at,
+        }
+
+    async def unblock_song(self, user_id: uuid.UUID, song_id: uuid.UUID) -> None:
+        """곡 차단 해제. 차단 내역이 없으면 404."""
+        result = await self.db.execute(
+            select(BlockedSong).where(
+                BlockedSong.user_id == user_id,
+                BlockedSong.song_id == song_id,
+            )
+        )
+        record = result.scalar_one_or_none()
+        if not record:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"code": "BLOCK_NOT_FOUND", "message": "차단 내역이 없습니다."},
+            )
+        await self.db.delete(record)
+        await self.db.flush()
+
     async def update_settings(
         self,
         user_id: uuid.UUID,
         update_data: dict,
     ) -> dict:
-        """
-        JSONB 부분 업데이트: 전달된 키만 머지.
-        새 dict 객체를 할당해 SQLAlchemy 변경 감지를 트리거.
-        """
+        """JSONB 부분 업데이트: 전달된 키만 머지."""
         user = await self.get_user(user_id)
         current = dict(user.settings or {})
         current.update(update_data)


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #114 


## 📤 Tasks

- 마이페이지 프로필 수정 API 구현 (`PATCH /users/me/profile`)
  - 닉네임, 소개글, 프로필 이미지 수정 (multipart/form-data)
- 유저 조회 API 확장 (`GET /users/me`)
  - bio, 연동 소셜 계정, 즐겨찾기 가수, 차단 가수 정보 포함

- 가수 차단 기능 구현
  - 가수 차단 / 조회 / 해제 API

- 곡 차단 기능 구현
  - 곡 차단 / 조회 / 해제 API

- DB 스키마 변경
  - User: `bio`, `kakao_id`, `naver_id` 컬럼 추가
  - `blocked_songs` 테이블 추가

<br/>

## 📸 Screenshot
<img width="1053" height="622" alt="image" src="https://github.com/user-attachments/assets/f011a2d8-7c49-4fb4-aa84-8fee2c5c8f70" />

<!-- 필요 시 첨부 -->

<br/>

## 💌 To Reviewer


<br/>