### PR TITLE
Feat(client): 보관함 폴더 및 위시리스트 API 연결

### DIFF
--- a/frontend/apps/client/src/entities/library/api/libraryApi.ts
+++ b/frontend/apps/client/src/entities/library/api/libraryApi.ts
@@ -1,0 +1,52 @@
+import { privateClient } from '@/shared/api/client';
+import type { FolderCreate, WishlistItemCreate } from '../model/types';
+
+export const libraryApi = {
+  // GET: 폴더 목록 조회
+  getFolders: async () => {
+    const { data, error } = await privateClient.GET('/api/v1/library/folders');
+    if (error) throw error;
+    return data;
+  },
+
+  // POST: 폴더 생성
+  createFolder: async (body: FolderCreate) => {
+    const { data, error } = await privateClient.POST('/api/v1/library/folders', { body });
+    if (error) throw error;
+    return data;
+  },
+
+  // DELETE: 폴더 삭제
+  deleteFolder: async (folderId: string) => {
+    const { error } = await privateClient.DELETE('/api/v1/library/folders/{folder_id}', {
+      params: { path: { folder_id: folderId } },
+    });
+    if (error) throw error;
+  },
+
+  // GET: 위시리스트 조회
+  getWishlist: async (folderId?: string) => {
+    const { data, error } = await privateClient.GET('/api/v1/library/wishlist', {
+      ...(folderId && { params: { query: { folder_id: folderId } } as any }),
+    });
+    if (error) throw error;
+    return data;
+  },
+
+  // POST: 위시리스트 곡 추가
+  addWishlistItem: async (body: WishlistItemCreate) => {
+    const { data, error } = await privateClient.POST('/api/v1/library/wishlist', {
+      body,
+    });
+    if (error) throw error;
+    return data;
+  },
+
+  // DELETE: 위시리스트 곡 삭제
+  deleteWishlistItem: async (itemId: string) => {
+    const { error } = await privateClient.DELETE('/api/v1/library/wishlist/{item_id}', {
+      params: { path: { item_id: itemId } },
+    });
+    if (error) throw error;
+  },
+};

--- a/frontend/apps/client/src/entities/library/index.ts
+++ b/frontend/apps/client/src/entities/library/index.ts
@@ -1,0 +1,22 @@
+export { libraryApi } from './api/libraryApi';
+export {
+  useFolders,
+  useCreateFolder,
+  useDeleteFolder,
+  useWishlist,
+  useAddWishlistItem,
+  useDeleteWishlistItem,
+} from './model/queries';
+export type {
+  FavoriteFolderApiType,
+  FavoriteFolderUiType,
+  FavoriteSongApiType,
+  FavoriteSongUiType,
+  HistoryItemApiType,
+  HistoryItemUiType,
+} from './model/types';
+export {
+  toFavoriteFolderUi,
+  toFavoriteSongUiType,
+  toHistoryItemUi,
+} from './model/mapper';

--- a/frontend/apps/client/src/entities/library/model/mapper.ts
+++ b/frontend/apps/client/src/entities/library/model/mapper.ts
@@ -1,5 +1,5 @@
 import { isHistoryTag } from './tags';
-import {
+import type {
   FavoriteFolderApiType,
   FavoriteFolderUiType,
   FavoriteSongApiType,
@@ -8,18 +8,26 @@ import {
   HistoryItemUiType,
 } from './types';
 
-export const toHistoryItemUi = (item: HistoryItemApiType): HistoryItemUiType => ({
-  historyId: item.history_id,
-  title: item.song.title,
-  artist: item.song.artist ?? '',
-  thumbnail: item.song.album_cover ?? undefined,
-  tags: (item.tags ?? []).filter(isHistoryTag),
-  memo: item.memo ?? undefined,
-  date: item.date,
-});
+export const toHistoryItemUi = (item: HistoryItemApiType): HistoryItemUiType => {
+  const date = new Date(item.recorded_date);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const formattedDate = `${year}.${month}.${day}`;
 
-const formatUpdatedAtLabel = (updatedAt: string) => {
-  const date = new Date(updatedAt);
+  return {
+    historyId: item.id,
+    title: item.song?.title ?? '',
+    artist: item.song?.artist ?? '',
+    thumbnail: item.song?.album_cover ?? undefined,
+    tags: (item.tags ?? []).filter(isHistoryTag),
+    memo: item.memo ?? undefined,
+    date: formattedDate,
+  };
+};
+
+const formatUpdatedAtLabel = (dateStr: string) => {
+  const date = new Date(dateStr);
   const today = new Date();
 
   const isSameDate =
@@ -37,20 +45,20 @@ const formatUpdatedAtLabel = (updatedAt: string) => {
 };
 
 export const toFavoriteFolderUi = (
-  folder: FavoriteFolderApiType
+  folder: FavoriteFolderApiType,
 ): FavoriteFolderUiType => ({
   id: folder.id,
   name: folder.name,
-  coverImages: folder.thumbnail ?? [],
-  songCount: folder.count,
-  updatedAt: formatUpdatedAtLabel(folder.updated_at),
+  coverImages: [],
+  songCount: folder.item_count,
+  updatedAt: formatUpdatedAtLabel(folder.created_at),
 });
 
 export const toFavoriteSongUiType = (item: FavoriteSongApiType): FavoriteSongUiType => ({
-  itemId: item.item_id,
+  itemId: item.id,
   songId: item.song.id,
   title: item.song.title,
   artist: item.song.artist,
   thumbnail: item.song.album_cover ?? undefined,
-  isLiked: item.is_liked,
+  isLiked: true,
 });

--- a/frontend/apps/client/src/entities/library/model/mock.ts
+++ b/frontend/apps/client/src/entities/library/model/mock.ts
@@ -1,13 +1,10 @@
-import type {
-  FavoriteFolderApiType,
-  FavoriteSongUiType,
-  HistoryItemApiType,
-} from './types';
-import { toFavoriteFolderUi, toHistoryItemUi } from './mapper';
+import type { HistoryItemApiType } from './types';
+import { toHistoryItemUi } from './mapper';
 
 const MOCK_HISTORY_ITEMS_API: HistoryItemApiType[] = [
   {
-    history_id: 'h1',
+    id: 'h1',
+    user_id: 'user1',
     song: {
       id: 's1',
       title: '야생화',
@@ -16,10 +13,11 @@ const MOCK_HISTORY_ITEMS_API: HistoryItemApiType[] = [
     },
     tags: ['AGAIN', 'PRACTICE'],
     memo: '전체적으로 리듬은 잘 맞았고 초반 흐름도 안정적이었음. 다만 후반부로 갈수록 호흡이 부족해지면서 음정이 점점 흔들렸음. 특히 고음 구간에서 목에 힘이 들어가 소리가 얇아지고 답답하게 들렸음. 녹음으로 다시 들어보니 발음이 뭉개지는 부분도 있었고, 감정 표현이 일정하지 않았음. 다음에는 호흡을 더 길게 가져가고 고음 파트를 따로 나눠 연습할 필요가 있음. 전체적으로 힘을 빼고 부르는 연습도 같이 해보면 좋을 것 같음.',
-    date: '2026.02.15',
+    recorded_date: '2026-02-15T10:00:00Z',
   },
   {
-    history_id: 'h2',
+    id: 'h2',
+    user_id: 'user1',
     song: {
       id: 's2',
       title: '밤편지',
@@ -28,10 +26,11 @@ const MOCK_HISTORY_ITEMS_API: HistoryItemApiType[] = [
     },
     tags: ['COMFORTABLE'],
     memo: null,
-    date: '2026.02.10',
+    recorded_date: '2026-02-10T14:30:00Z',
   },
   {
-    history_id: 'h3',
+    id: 'h3',
+    user_id: 'user1',
     song: {
       id: 's3',
       title: '사건의 지평선',
@@ -40,38 +39,8 @@ const MOCK_HISTORY_ITEMS_API: HistoryItemApiType[] = [
     },
     tags: ['BAD_CONDITION', 'NOT_MY_STYLE'],
     memo: '키가 높아서 힘들었음',
-    date: '2026.02.03',
+    recorded_date: '2026-02-03T18:00:00Z',
   },
 ];
 
 export const MOCK_HISTORY_ITEMS = MOCK_HISTORY_ITEMS_API.map(toHistoryItemUi);
-
-export const MOCK_FAVORITE_FOLDERS_API: FavoriteFolderApiType[] = [
-  {
-    id: 'f1',
-    name: '남자친구랑 데이트',
-    thumbnail: ['', '', '', ''],
-    count: 4,
-    updated_at: '2026-03-10T09:30:00Z',
-  },
-  {
-    id: 'f2',
-    name: '등교할 때',
-    thumbnail: ['', '', '', ''],
-    count: 11,
-    updated_at: '2026-03-01T12:00:00Z',
-  },
-];
-
-export const MOCK_FAVORITE_FOLDERS = MOCK_FAVORITE_FOLDERS_API.map(toFavoriteFolderUi);
-
-export const MOCK_FAVORITE_SONGS: FavoriteSongUiType[] = [
-  { itemId: '1', songId: '1', title: '전설', artist: '잔나비', isLiked: true },
-  {
-    itemId: '2',
-    songId: '2',
-    title: 'NOT CUTE ANYMORE',
-    artist: '아일릿(ILLIT)',
-    isLiked: true,
-  },
-];

--- a/frontend/apps/client/src/entities/library/model/queries.ts
+++ b/frontend/apps/client/src/entities/library/model/queries.ts
@@ -1,6 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { libraryApi } from '../api/libraryApi';
-import type { FolderCreate, WishlistItemCreate, FavoriteFolderApiType } from '../model/types';
+import type {
+  FolderCreate,
+  WishlistItemCreate,
+  FavoriteFolderApiType,
+} from '../model/types';
 import { queryKeys } from '@/shared/api/queryKeys';
 import { toFavoriteFolderUi, toFavoriteSongUiType } from './mapper';
 
@@ -21,14 +25,16 @@ export const useCreateFolder = () => {
   });
 };
 
-// DELETE: 폴더 삭제 (낙관적 업데이트)
+// DELETE: 폴더 삭제
 export const useDeleteFolder = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (folderId: string) => libraryApi.deleteFolder(folderId),
     onMutate: async (folderId) => {
       await queryClient.cancelQueries({ queryKey: queryKeys.folders });
-      const previous = queryClient.getQueryData<FavoriteFolderApiType[]>(queryKeys.folders);
+      const previous = queryClient.getQueryData<FavoriteFolderApiType[]>(
+        queryKeys.folders,
+      );
       queryClient.setQueryData<FavoriteFolderApiType[]>(queryKeys.folders, (old = []) =>
         old.filter((f) => f.id !== folderId),
       );

--- a/frontend/apps/client/src/entities/library/model/queries.ts
+++ b/frontend/apps/client/src/entities/library/model/queries.ts
@@ -1,0 +1,68 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { libraryApi } from '../api/libraryApi';
+import type { FolderCreate, WishlistItemCreate, FavoriteFolderApiType } from '../model/types';
+import { queryKeys } from '@/shared/api/queryKeys';
+import { toFavoriteFolderUi, toFavoriteSongUiType } from './mapper';
+
+// GET: 폴더 목록 조회
+export const useFolders = () =>
+  useQuery({
+    queryKey: queryKeys.folders,
+    queryFn: libraryApi.getFolders,
+    select: (data) => data.map(toFavoriteFolderUi),
+  });
+
+// POST: 폴더 생성
+export const useCreateFolder = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: FolderCreate) => libraryApi.createFolder(body),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.folders }),
+  });
+};
+
+// DELETE: 폴더 삭제 (낙관적 업데이트)
+export const useDeleteFolder = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (folderId: string) => libraryApi.deleteFolder(folderId),
+    onMutate: async (folderId) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.folders });
+      const previous = queryClient.getQueryData<FavoriteFolderApiType[]>(queryKeys.folders);
+      queryClient.setQueryData<FavoriteFolderApiType[]>(queryKeys.folders, (old = []) =>
+        old.filter((f) => f.id !== folderId),
+      );
+      return { previous };
+    },
+    onError: (_err, _folderId, context) => {
+      queryClient.setQueryData(queryKeys.folders, context?.previous);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.folders }),
+  });
+};
+
+// GET: 위시리스트 조회
+export const useWishlist = (folderId?: string) =>
+  useQuery({
+    queryKey: queryKeys.wishlist(folderId),
+    queryFn: () => libraryApi.getWishlist(folderId),
+    select: (data) => data.map(toFavoriteSongUiType),
+  });
+
+// POST: 위시리스트에 곡 추가
+export const useAddWishlistItem = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: WishlistItemCreate) => libraryApi.addWishlistItem(body),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['library', 'wishlist'] }),
+  });
+};
+
+// DELETE: 위시리스트 아이템 삭제
+export const useDeleteWishlistItem = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (itemId: string) => libraryApi.deleteWishlistItem(itemId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['library', 'wishlist'] }),
+  });
+};

--- a/frontend/apps/client/src/entities/library/model/types.ts
+++ b/frontend/apps/client/src/entities/library/model/types.ts
@@ -1,13 +1,11 @@
-import type { SongApiType } from '@/entities/song/model/types';
+import type { components } from '@singchronize/api';
 import { HistoryTagType } from './tags';
 
-export type HistoryItemApiType = {
-  history_id: string;
-  song: SongApiType;
-  tags: string[];
-  memo?: string | null;
-  date: string; // "2026.02.15"
-};
+export type HistoryItemApiType = components['schemas']['ArchiveResponse'];
+export type FavoriteFolderApiType = components['schemas']['FolderResponse'];
+export type FolderCreate = components['schemas']['FolderCreate'];
+export type FavoriteSongApiType = components['schemas']['WishlistItemResponse'];
+export type WishlistItemCreate = components['schemas']['WishlistItemCreate'];
 
 export type HistoryItemUiType = {
   historyId: string;
@@ -19,41 +17,19 @@ export type HistoryItemUiType = {
   date: string;
 };
 
-export interface FavoriteFolderApiType {
-  id: string;
-  name: string;
-  thumbnail?: string[];
-  count: number;
-  updated_at: string;
-}
-
-export interface FavoriteFoldersResponse {
-  folders: FavoriteFolderApiType[];
-}
-
-export interface FavoriteFolderUiType {
+export type FavoriteFolderUiType = {
   id: string;
   name: string;
   coverImages: string[];
   songCount: number;
   updatedAt: string;
-}
+};
 
-export interface FavoriteSongApiType {
-  item_id: string;
-  song: SongApiType;
-  is_liked: boolean;
-}
-
-export interface FavoriteSongsResponse {
-  items: FavoriteSongApiType[];
-}
-
-export interface FavoriteSongUiType {
+export type FavoriteSongUiType = {
   itemId: string;
   songId: string;
   title: string;
   artist: string;
   thumbnail?: string;
   isLiked: boolean;
-}
+};

--- a/frontend/apps/client/src/entities/song/ui/LikeIconButton.tsx
+++ b/frontend/apps/client/src/entities/song/ui/LikeIconButton.tsx
@@ -3,15 +3,17 @@ import { IcHeartOff, IcHeartOn } from '@/shared/assets/icons';
 type LikeIconButtonProps = {
   isLiked: boolean;
   onClick?: () => void;
+  disabled?: boolean;
 };
 
-const LikeIconButton = ({ isLiked, onClick }: LikeIconButtonProps) => {
+const LikeIconButton = ({ isLiked, onClick, disabled }: LikeIconButtonProps) => {
   return (
     <button
       type='button'
       aria-label={isLiked ? '좋아요 취소' : '좋아요'}
       aria-pressed={isLiked}
       onClick={onClick}
+      disabled={disabled}
       className='inline-flex items-center justify-center'
     >
       {isLiked ? <IcHeartOn /> : <IcHeartOff />}

--- a/frontend/apps/client/src/features/add-favorite/ui/AddFavoriteModal.tsx
+++ b/frontend/apps/client/src/features/add-favorite/ui/AddFavoriteModal.tsx
@@ -4,27 +4,33 @@ import { useState } from 'react';
 import { InputField } from '@singchronize/ui';
 import { BaseModal } from '@/shared/components';
 import { LikeIconButton, SongListItem } from '@/entities/song/ui';
-
 import { useSearchMusic } from '@/entities/song';
+import { useAddWishlistItem } from '@/entities/library';
 
 type AddFavoriteModalProps = {
+  folderId?: string;
   onClose: () => void;
 };
 
-const AddFavoriteModal = ({ onClose }: AddFavoriteModalProps) => {
+const AddFavoriteModal = ({ folderId, onClose }: AddFavoriteModalProps) => {
   const [query, setQuery] = useState('');
   const [likedIds, setLikedIds] = useState<Set<string>>(() => new Set());
+
+  const { mutate: addWishlistItem, isPending: isAdding } = useAddWishlistItem();
+  const { data: searchedItems = [] } = useSearchMusic(query);
 
   const toggleLike = (id: string) => {
     setLikedIds((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+        addWishlistItem({ song_id: id, folder_id: folderId });
+      }
       return next;
     });
   };
-
-  const { data: searchedItems = [] } = useSearchMusic(query);
 
   return (
     <BaseModal
@@ -59,6 +65,7 @@ const AddFavoriteModal = ({ onClose }: AddFavoriteModalProps) => {
                   <LikeIconButton
                     isLiked={likedIds.has(String(song.id))}
                     onClick={() => toggleLike(String(song.id))}
+                    disabled={isAdding}
                   />
                 }
               />

--- a/frontend/apps/client/src/features/add-favorite/ui/AddFolderModal.tsx
+++ b/frontend/apps/client/src/features/add-favorite/ui/AddFolderModal.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { InputField, Button } from '@singchronize/ui';
 import { BaseModal } from '@/shared/components';
 import { IcCheck, IcPlus } from '@/shared/assets/icons';
 import { SongListItem } from '@/entities/song/ui';
-import { SongUiType } from '@/entities/song/model/types';
 
-import { MOCK_SONG_LIST } from '@/entities/song/model/mock';
+import { useSearchMusic } from '@/entities/song';
+import { useCreateFolder, useAddWishlistItem } from '@/entities/library';
 
 type AddFolderModalProps = {
   onClose: () => void;
@@ -17,28 +17,36 @@ const AddFolderModal = ({ onClose }: AddFolderModalProps) => {
   const [folderTitle, setFolderTitle] = useState('');
   const [query, setQuery] = useState('');
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [songs, setSongs] = useState<SongUiType[]>([]);
 
-  useEffect(() => {
-    // TODO: 곡 목록 fetch API 호출
-    setSongs(MOCK_SONG_LIST);
-  }, []);
+  const { mutate: createFolder, isPending: isCreatingFolder } = useCreateFolder();
+  const { mutate: addWishlistItem } = useAddWishlistItem();
 
-  const filteredSongs = songs.filter(
-    (song) =>
-      song.title.toLowerCase().includes(query.toLowerCase()) ||
-      song.artist.toLowerCase().includes(query.toLowerCase())
-  );
+  const { data: searchedItems = [] } = useSearchMusic(query);
 
   const toggle = (id: string) => {
     setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
     );
   };
 
   const handleSave = async () => {
-    // TODO: 폴더 생성 + 곡 추가 API 호출
-    onClose();
+    if (!folderTitle.trim()) return;
+
+    createFolder(
+      { name: folderTitle },
+      {
+        onSuccess: (createdFolder) => {
+          // 선택된 곡들을 폴더에 추가
+          selectedIds.forEach((songId) => {
+            addWishlistItem({
+              song_id: songId,
+              folder_id: createdFolder.id,
+            });
+          });
+          onClose();
+        },
+      },
+    );
   };
 
   return (
@@ -65,7 +73,7 @@ const AddFolderModal = ({ onClose }: AddFolderModalProps) => {
           />
 
           <div className='flex flex-col gap-4'>
-            {filteredSongs.map((song) => {
+            {searchedItems.map((song) => {
               const isSelected = selectedIds.includes(String(song.id));
               return (
                 <SongListItem
@@ -97,7 +105,11 @@ const AddFolderModal = ({ onClose }: AddFolderModalProps) => {
       </div>
 
       <div className='py-7 flex justify-center shrink-0'>
-        <Button variant='primary' onClick={handleSave} disabled={!folderTitle.trim()}>
+        <Button
+          variant='primary'
+          onClick={handleSave}
+          disabled={!folderTitle.trim() || isCreatingFolder}
+        >
           저장하기
         </Button>
       </div>

--- a/frontend/apps/client/src/features/like/ui/SongLikeButton.tsx
+++ b/frontend/apps/client/src/features/like/ui/SongLikeButton.tsx
@@ -1,16 +1,26 @@
 'use client';
 
 import { LikeIconButton } from '@/entities/song/ui';
+import { useWishlist, useDeleteWishlistItem } from '@/entities/library';
 
 type SongLikeButtonProps = {
-  songId: string;
   isLiked: boolean;
+  songId: string;
+  folderId?: string;
 };
 
-const SongLikeButton = ({ songId, isLiked }: SongLikeButtonProps) => {
+const SongLikeButton = ({ isLiked, songId, folderId }: SongLikeButtonProps) => {
+  const { data: wishlist = [] } = useWishlist(folderId);
+  const { mutate: deleteWishlistItem } = useDeleteWishlistItem();
+
   const handleClick = () => {
-    // TODO: 찜하기 API 연결
-    console.log('like', songId);
+    if (isLiked && folderId) {
+      const item = wishlist.find((w) => w.songId === songId);
+      if (item) deleteWishlistItem(item.itemId);
+    } else {
+      // TODO: 찜하기 API 연결
+      console.log('like', songId);
+    }
   };
 
   return <LikeIconButton isLiked={isLiked} onClick={handleClick} />;

--- a/frontend/apps/client/src/shared/api/queryKeys.ts
+++ b/frontend/apps/client/src/shared/api/queryKeys.ts
@@ -5,4 +5,6 @@ export const queryKeys = {
   searchMusic: (q: string) => ['music', 'search', q] as const,
   searchSingers: (q: string) => ['singers', 'search', q] as const,
   randomSingers: (gender: string) => ['singers', 'random', gender] as const,
+  folders: ['library', 'folders'] as const,
+  wishlist: (folderId?: string) => ['library', 'wishlist', folderId ?? 'all'] as const,
 };

--- a/frontend/apps/client/src/widgets/library/ui/FavoriteFolderDetail.tsx
+++ b/frontend/apps/client/src/widgets/library/ui/FavoriteFolderDetail.tsx
@@ -8,20 +8,19 @@ import { AddFavoriteModal } from '@/features/add-favorite';
 import { SongBlockMenu } from '@/features/block';
 import { SongLikeButton } from '@/features/like';
 import { SongListItem } from '@/entities/song/ui';
+import type { FavoriteFolderUiType } from '@/entities/library/model/types';
 
-import type {
-  FavoriteFolderUiType,
-  FavoriteSongUiType,
-} from '@/entities/library/model/types';
+import { useWishlist } from '@/entities/library';
 
 interface FavoriteFolderDetailProps {
   folder: FavoriteFolderUiType;
-  songs: FavoriteSongUiType[];
   onBack: () => void;
 }
 
-const FavoriteFolderDetail = ({ folder, songs, onBack }: FavoriteFolderDetailProps) => {
+const FavoriteFolderDetail = ({ folder, onBack }: FavoriteFolderDetailProps) => {
   const { open: isAddModalOpen, openModal, closeModal } = useModal(false);
+
+  const { data: songs = [] } = useWishlist(folder.id);
 
   return (
     <section className='flex flex-col'>
@@ -49,7 +48,11 @@ const FavoriteFolderDetail = ({ folder, songs, onBack }: FavoriteFolderDetailPro
               artist={song.artist}
               rightSlot={
                 <div className='flex items-center gap-4'>
-                  <SongLikeButton songId={song.songId} isLiked={song.isLiked} />
+                  <SongLikeButton
+                    isLiked={song.isLiked}
+                    songId={song.songId}
+                    folderId={folder.id}
+                  />
                   <SongBlockMenu songId={song.songId} />
                 </div>
               }
@@ -58,7 +61,7 @@ const FavoriteFolderDetail = ({ folder, songs, onBack }: FavoriteFolderDetailPro
         ))}
       </ul>
 
-      {isAddModalOpen && <AddFavoriteModal onClose={closeModal} />}
+      {isAddModalOpen && <AddFavoriteModal folderId={folder.id} onClose={closeModal} />}
     </section>
   );
 };

--- a/frontend/apps/client/src/widgets/library/ui/LibraryFavoriteList.tsx
+++ b/frontend/apps/client/src/widgets/library/ui/LibraryFavoriteList.tsx
@@ -8,24 +8,19 @@ import { FavoriteFolderCard } from '@/entities/library/ui';
 import type { FavoriteFolderUiType } from '@/entities/library/model/types';
 import FavoriteFolderDetail from './FavoriteFolderDetail';
 
-import {
-  MOCK_FAVORITE_FOLDERS,
-  MOCK_FAVORITE_SONGS,
-} from '@/entities/library/model/mock';
+import { useFolders, useDeleteFolder } from '@/entities/library';
 
 const LibraryFavoriteList = () => {
   const { open: isAddModalOpen, openModal, closeModal } = useModal(false);
-
   const [selectedFolder, setSelectedFolder] = useState<FavoriteFolderUiType | null>(null);
 
-  const folders = MOCK_FAVORITE_FOLDERS;
-  const songs = MOCK_FAVORITE_SONGS;
+  const { data: folders = [] } = useFolders();
+  const { mutate: deleteFolder } = useDeleteFolder();
 
   if (selectedFolder) {
     return (
       <FavoriteFolderDetail
         folder={selectedFolder}
-        songs={songs}
         onBack={() => setSelectedFolder(null)}
       />
     );
@@ -45,8 +40,8 @@ const LibraryFavoriteList = () => {
             <FavoriteFolderCard
               folder={folder}
               onClick={() => setSelectedFolder(folder)}
-              onRenameClick={() => {}}
-              onDeleteClick={() => {}}
+              onRenameClick={() => {}} // TODO: 폴더 이름 변경 기능 논의 필요
+              onDeleteClick={() => deleteFolder(folder.id)}
             />
           </li>
         ))}


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #140


## 📤 Tasks
<!-- 해당 PR에 대한 작업 내용을 작성해주세요. -->
- GET /api/v1/library/folders — 폴더 목록 조회 API 연결
- POST /api/v1/library/folders — 폴더 생성 API 연결
- DELETE /api/v1/library/folders/{folder_id} — 폴더 삭제 API 연결 및 낙관적 업데이트 적용
- GET /api/v1/library/wishlist — 위시리스트 조회 API 연결
- DELETE /api/v1/library/wishlist/{item_id} — 위시리스트 곡 삭제 API 연결
- 기존 mock 데이터 제거, 스키마 기반 타입으로 교체

<br/>

## 💌 To Reviewer
<!-- 리뷰어가 집중해주면 좋을 부분/논의할 부분이 있다면 작성해주세요. -->
- **POST /api/v1/library/wishlist 동작 불가**

/api/v1/music/search 응답에 song_id가 존재하지 않아 위시리스트 추가 요청 시 422가 발생합니다.
song_id 필드 추가 부탁드립니다. 🙇‍♀️

- **폴더 이름 변경 API / UI 미존재**

사실 그렇게 필수적인 기능은 아니라 제외하는 게 나을 것 같습니다.

- **위시리스트에 곡 추가 시 폴더 지정 모달 부재**

현재 위시리스트에 곡 추가 시(찜 버튼 클릭 시) 폴더를 지정하는 흐름이 존재하지 않습니다.
따라서, 디자이너와 논의 후 모달을 추가해야 합니다.

<br/>
