### PR TITLE
Refactor(server): Library Spotify JSONB 구조 변경

### DIFF
--- a/backend/app/models/archive.py
+++ b/backend/app/models/archive.py
@@ -1,9 +1,8 @@
 """Archive 모델 - 부른 노래 기록"""
 import uuid
 from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Uuid
-from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.sql import func
-from sqlalchemy.orm import relationship
 
 from app.database import Base
 
@@ -13,9 +12,8 @@ class Archive(Base):
 
     id = Column(Uuid, primary_key=True, default=uuid.uuid4)
     user_id = Column(Uuid, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
-    song_id = Column(Uuid, ForeignKey("songs.id", ondelete="SET NULL"), nullable=True)
+    # Spotify 검색 결과 JSON 그대로 저장 { name, artist, album_image, uri }
+    song_data = Column(JSONB, nullable=False)
     tags = Column(ARRAY(String), default=list)
     memo = Column(Text, nullable=True)
     recorded_date = Column(DateTime(timezone=True), server_default=func.now())
-
-    song = relationship("Song")

--- a/backend/app/models/library.py
+++ b/backend/app/models/library.py
@@ -1,6 +1,7 @@
 """Library 모델 - Folder & WishlistItem"""
 import uuid
-from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, Uuid, UniqueConstraint
+from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, Uuid
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 
@@ -25,12 +26,8 @@ class WishlistItem(Base):
     id = Column(Uuid, primary_key=True, default=uuid.uuid4)
     user_id = Column(Uuid, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     folder_id = Column(Uuid, ForeignKey("folders.id", ondelete="SET NULL"), nullable=True, index=True)
-    song_id = Column(Uuid, ForeignKey("songs.id", ondelete="CASCADE"), nullable=False)
+    # Spotify 검색 결과 JSON 그대로 저장 { name, artist, album_image, uri }
+    song_data = Column(JSONB, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     folder = relationship("Folder", back_populates="items")
-    song = relationship("Song")
-
-    __table_args__ = (
-        UniqueConstraint("folder_id", "song_id", name="uq_folder_song"),
-    )

--- a/backend/app/routers/library.py
+++ b/backend/app/routers/library.py
@@ -1,11 +1,10 @@
-"""Library & Archive 라우터 - 폴더, 위시리스트, 부른 노래 기록, 차단"""
+"""Library & Archive 라우터 - 폴더, 위시리스트, 부른 노래 기록"""
 from uuid import UUID
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status  # noqa: F401
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, func, delete
-from sqlalchemy.orm import selectinload
+from sqlalchemy import select, func
 
 from app.database import get_db
 from app.dependencies.auth import get_current_user
@@ -22,7 +21,7 @@ router = APIRouter(prefix="/api/v1/library", tags=["Library"])
 
 
 # ═══════════════════════════════════════════════════
-# Folder endpoints
+# Folder
 # ═══════════════════════════════════════════════════
 
 @router.get("/folders", response_model=List[FolderResponse])
@@ -30,30 +29,19 @@ async def get_folders(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """사용자의 모든 폴더 조회 (아이템 개수 포함)"""
-    stmt = (
-        select(
-            Folder,
-            func.count(WishlistItem.id).label("item_count"),
-        )
+    rows = (await db.execute(
+        select(Folder, func.count(WishlistItem.id).label("item_count"))
         .outerjoin(WishlistItem, WishlistItem.folder_id == Folder.id)
         .where(Folder.user_id == current_user.id)
         .group_by(Folder.id)
         .order_by(Folder.created_at)
-    )
-    result = await db.execute(stmt)
-    rows = result.all()
-
+    )).all()
     return [
         FolderResponse(
-            id=folder.id,
-            user_id=folder.user_id,
-            name=folder.name,
-            is_system=folder.is_system,
-            created_at=folder.created_at,
-            item_count=item_count,
+            id=f.id, user_id=f.user_id, name=f.name,
+            is_system=f.is_system, created_at=f.created_at, item_count=cnt,
         )
-        for folder, item_count in rows
+        for f, cnt in rows
     ]
 
 
@@ -63,23 +51,13 @@ async def create_folder(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """새 폴더 생성"""
-    folder = Folder(
-        user_id=current_user.id,
-        name=body.name,
-        is_system=False,
-    )
+    folder = Folder(user_id=current_user.id, name=body.name, is_system=False)
     db.add(folder)
     await db.flush()
     await db.refresh(folder)
-
     return FolderResponse(
-        id=folder.id,
-        user_id=folder.user_id,
-        name=folder.name,
-        is_system=folder.is_system,
-        created_at=folder.created_at,
-        item_count=0,
+        id=folder.id, user_id=folder.user_id, name=folder.name,
+        is_system=folder.is_system, created_at=folder.created_at, item_count=0,
     )
 
 
@@ -89,45 +67,33 @@ async def delete_folder(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """폴더 삭제 (시스템 폴더는 삭제 불가)"""
-    stmt = select(Folder).where(Folder.id == folder_id, Folder.user_id == current_user.id)
-    result = await db.execute(stmt)
-    folder = result.scalar_one_or_none()
-
+    folder = (await db.execute(
+        select(Folder).where(Folder.id == folder_id, Folder.user_id == current_user.id)
+    )).scalar_one_or_none()
     if not folder:
         raise HTTPException(status_code=404, detail="폴더를 찾을 수 없습니다.")
     if folder.is_system:
         raise HTTPException(status_code=400, detail="시스템 폴더는 삭제할 수 없습니다.")
-
     await db.delete(folder)
 
 
 # ═══════════════════════════════════════════════════
-# Wishlist endpoints
+# Wishlist
 # ═══════════════════════════════════════════════════
 
 @router.get("/wishlist", response_model=List[WishlistItemResponse])
 async def get_wishlist(
-    folder_id: Optional[UUID] = Query(None, description="폴더 ID (없으면 전체)"),
-    sort: str = Query("LATEST", description="정렬 기준 (LATEST)"),
+    folder_id: Optional[UUID] = Query(None),
+    sort: str = Query("LATEST"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """위시리스트 아이템 조회"""
-    stmt = (
-        select(WishlistItem)
-        .options(selectinload(WishlistItem.song))
-        .where(WishlistItem.user_id == current_user.id)
-    )
-
+    stmt = select(WishlistItem).where(WishlistItem.user_id == current_user.id)
     if folder_id is not None:
         stmt = stmt.where(WishlistItem.folder_id == folder_id)
-
     if sort == "LATEST":
         stmt = stmt.order_by(WishlistItem.created_at.desc())
-
-    result = await db.execute(stmt)
-    return result.scalars().all()
+    return (await db.execute(stmt)).scalars().all()
 
 
 @router.post("/wishlist", response_model=WishlistItemResponse, status_code=status.HTTP_201_CREATED)
@@ -136,41 +102,22 @@ async def add_wishlist_item(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """위시리스트에 곡 추가"""
-    # 폴더 존재 확인 (folder_id가 있는 경우)
+    """Spotify 검색 결과를 찜 목록에 추가. song_data = { name, artist, album_image, uri }"""
     if body.folder_id is not None:
-        folder_check = await db.execute(
+        if not (await db.execute(
             select(Folder.id).where(Folder.id == body.folder_id, Folder.user_id == current_user.id)
-        )
-        if not folder_check.scalar_one_or_none():
+        )).scalar_one_or_none():
             raise HTTPException(status_code=404, detail="폴더를 찾을 수 없습니다.")
-
-    # 중복 체크
-    dup_stmt = select(WishlistItem).where(
-        WishlistItem.user_id == current_user.id,
-        WishlistItem.folder_id == body.folder_id,
-        WishlistItem.song_id == body.song_id,
-    )
-    dup_result = await db.execute(dup_stmt)
-    if dup_result.scalar_one_or_none():
-        raise HTTPException(status_code=409, detail="이미 위시리스트에 추가된 곡입니다.")
 
     item = WishlistItem(
         user_id=current_user.id,
         folder_id=body.folder_id,
-        song_id=body.song_id,
+        song_data=body.song_data,
     )
     db.add(item)
     await db.flush()
-
-    # song relationship을 로드하기 위해 재조회
-    stmt = (
-        select(WishlistItem)
-        .options(selectinload(WishlistItem.song))
-        .where(WishlistItem.id == item.id)
-    )
-    result = await db.execute(stmt)
-    return result.scalar_one()
+    await db.refresh(item)
+    return item
 
 
 @router.delete("/wishlist/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -179,41 +126,29 @@ async def delete_wishlist_item(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """위시리스트 아이템 삭제"""
-    stmt = select(WishlistItem).where(WishlistItem.id == item_id, WishlistItem.user_id == current_user.id)
-    result = await db.execute(stmt)
-    item = result.scalar_one_or_none()
-
+    item = (await db.execute(
+        select(WishlistItem).where(WishlistItem.id == item_id, WishlistItem.user_id == current_user.id)
+    )).scalar_one_or_none()
     if not item:
-        raise HTTPException(status_code=404, detail="위시리스트 아이템을 찾을 수 없습니다.")
-
+        raise HTTPException(status_code=404, detail="찜 아이템을 찾을 수 없습니다.")
     await db.delete(item)
 
 
 # ═══════════════════════════════════════════════════
-# Archive / History endpoints
+# Archive / History
 # ═══════════════════════════════════════════════════
 
 @router.get("/history", response_model=List[ArchiveResponse])
 async def get_history(
-    tag: Optional[str] = Query(None, description="태그 필터 (예: AGAIN, HIGH_PITCH)"),
+    tag: Optional[str] = Query(None),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """부른 노래 기록 조회"""
-    stmt = (
-        select(Archive)
-        .options(selectinload(Archive.song))
-        .where(Archive.user_id == current_user.id)
-    )
-
+    stmt = select(Archive).where(Archive.user_id == current_user.id)
     if tag is not None:
         stmt = stmt.where(Archive.tags.any(tag))
-
     stmt = stmt.order_by(Archive.recorded_date.desc())
-
-    result = await db.execute(stmt)
-    return result.scalars().all()
+    return (await db.execute(stmt)).scalars().all()
 
 
 @router.post("/history", response_model=ArchiveResponse, status_code=status.HTTP_201_CREATED)
@@ -222,23 +157,17 @@ async def create_history(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """부른 노래 기록 저장"""
+    """Spotify 검색 결과를 가창 기록에 저장. song_data = { name, artist, album_image, uri }"""
     archive = Archive(
         user_id=current_user.id,
-        song_id=body.song_id,
+        song_data=body.song_data,
         tags=body.tags,
         memo=body.memo,
     )
     db.add(archive)
     await db.flush()
-
-    stmt = (
-        select(Archive)
-        .options(selectinload(Archive.song))
-        .where(Archive.id == archive.id)
-    )
-    result = await db.execute(stmt)
-    return result.scalar_one()
+    await db.refresh(archive)
+    return archive
 
 
 @router.patch("/history/{archive_id}", response_model=ArchiveResponse)
@@ -248,28 +177,18 @@ async def update_history(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """부른 노래 기록 수정 (태그, 메모)"""
-    stmt = select(Archive).where(Archive.id == archive_id, Archive.user_id == current_user.id)
-    result = await db.execute(stmt)
-    archive = result.scalar_one_or_none()
-
+    archive = (await db.execute(
+        select(Archive).where(Archive.id == archive_id, Archive.user_id == current_user.id)
+    )).scalar_one_or_none()
     if not archive:
         raise HTTPException(status_code=404, detail="기록을 찾을 수 없습니다.")
-
     if body.tags is not None:
         archive.tags = body.tags
     if body.memo is not None:
         archive.memo = body.memo
-
     await db.flush()
-
-    stmt = (
-        select(Archive)
-        .options(selectinload(Archive.song))
-        .where(Archive.id == archive.id)
-    )
-    result = await db.execute(stmt)
-    return result.scalar_one()
+    await db.refresh(archive)
+    return archive
 
 
 @router.delete("/history/{archive_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -278,14 +197,9 @@ async def delete_history(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """부른 노래 기록 삭제"""
-    stmt = select(Archive).where(Archive.id == archive_id, Archive.user_id == current_user.id)
-    result = await db.execute(stmt)
-    archive = result.scalar_one_or_none()
-
+    archive = (await db.execute(
+        select(Archive).where(Archive.id == archive_id, Archive.user_id == current_user.id)
+    )).scalar_one_or_none()
     if not archive:
         raise HTTPException(status_code=404, detail="기록을 찾을 수 없습니다.")
-
     await db.delete(archive)
-
-

--- a/backend/app/schemas/archive.py
+++ b/backend/app/schemas/archive.py
@@ -1,12 +1,13 @@
 """Archive 스키마 - 부른 노래 기록"""
 from pydantic import BaseModel
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 from datetime import datetime
 
 
 class ArchiveCreate(BaseModel):
-    song_id: UUID
+    # Spotify 검색 결과 그대로: { name, artist, album_image, uri }
+    song_data: Dict[str, Any]
     tags: List[str] = []
     memo: Optional[str] = None
 
@@ -16,19 +17,10 @@ class ArchiveUpdate(BaseModel):
     memo: Optional[str] = None
 
 
-class ArchiveSongInfo(BaseModel):
-    id: UUID
-    title: str
-    artist: str
-    album_cover: Optional[str] = None
-
-    model_config = {"from_attributes": True}
-
-
 class ArchiveResponse(BaseModel):
     id: UUID
     user_id: UUID
-    song: Optional[ArchiveSongInfo] = None
+    song_data: Dict[str, Any]
     tags: List[str] = []
     memo: Optional[str] = None
     recorded_date: datetime

--- a/backend/app/schemas/library.py
+++ b/backend/app/schemas/library.py
@@ -1,6 +1,6 @@
 """Library 스키마 - Folder & Wishlist"""
 from pydantic import BaseModel
-from typing import List, Optional
+from typing import Any, Dict, Optional
 from uuid import UUID
 from datetime import datetime
 
@@ -25,24 +25,16 @@ class FolderResponse(BaseModel):
 # ── WishlistItem ────────────────────────────────────
 
 class WishlistItemCreate(BaseModel):
-    song_id: UUID
+    # Spotify 검색 결과 그대로: { name, artist, album_image, uri }
+    song_data: Dict[str, Any]
     folder_id: Optional[UUID] = None
-
-
-class WishlistSongInfo(BaseModel):
-    id: UUID
-    title: str
-    artist: str
-    album_cover: Optional[str] = None
-
-    model_config = {"from_attributes": True}
 
 
 class WishlistItemResponse(BaseModel):
     id: UUID
     user_id: UUID
     folder_id: Optional[UUID] = None
-    song: WishlistSongInfo
+    song_data: Dict[str, Any]
     created_at: datetime
 
     model_config = {"from_attributes": True}


### PR DESCRIPTION
## 📌 Related Issue

- Closes #145 


## 📤 Tasks

- Library 구조 리팩토링 (songs FK 제거)
  - WishlistItem: song_id → song_data(JSONB)
  - Archive: song_id → song_data(JSONB)

- API 수정
  - song_data 기반으로 직접 저장하도록 변경
  - songs 테이블 의존성 제거

- 스키마 수정
  - song_data Dict 형태로 변경

- DB 마이그레이션
  - song_id 컬럼 제거
  - song_data JSONB 컬럼 추가


<br/>

## 📸 Screenshot

<!-- 필요 시 첨부 -->


<br/>

## 💌 To Reviewer

- 기존 songs 테이블과 완전히 분리된 구조입니다.
- JSONB 설계 및 API 응답 구조 위주로 확인 부탁드립니다.