### PR TITLE
Feat(server): 어드민페이지 확장 개선

### DIFF
--- a/backend/static/admin.html
+++ b/backend/static/admin.html
@@ -190,6 +190,19 @@
   .text-sm { font-size: 12px; color: var(--text2); }
   .flex-center { display: flex; align-items: center; gap: 8px; }
   .profile-img { width: 48px; height: 48px; border-radius: 50%; object-fit: cover; background: var(--bg3); }
+
+  /* API description */
+  .api-desc {
+    background: var(--bg3); border-left: 3px solid var(--purple); border-radius: 0 6px 6px 0;
+    padding: 10px 14px; margin-bottom: 14px; font-size: 12px; color: var(--text2); line-height: 1.7;
+  }
+  .api-desc code {
+    background: rgba(124,58,237,.2); color: var(--purple-light);
+    padding: 1px 5px; border-radius: 3px; font-family: 'Consolas','Fira Code',monospace; font-size: 11px;
+  }
+  .api-desc b { color: var(--text); }
+  .field-hint { font-size: 11px; color: var(--text2); margin-top: 3px; line-height: 1.5; }
+  .required { color: var(--red); font-size: 11px; margin-left: 3px; }
 </style>
 </head>
 <body>
@@ -220,7 +233,9 @@
     <a onclick="showSection('wishlist', this)">찜</a>
     <a onclick="showSection('history', this)">가창 기록</a>
     <div class="nav-group">Recommendation</div>
-    <a onclick="showSection('recommendation', this)">추천</a>
+    <a onclick="showSection('analysis', this)">보컬 분석</a>
+    <a onclick="showSection('recommendation', this)">추천 파이프라인</a>
+    <a onclick="showSection('artist-actions', this)">아티스트 액션</a>
     <div class="nav-group">Busking</div>
     <a onclick="showSection('busking-rooms', this)">방 목록/생성</a>
     <a onclick="showSection('busking-ctrl', this)">방 제어</a>
@@ -264,12 +279,13 @@
 
   <!-- ── PROFILE ── -->
   <div id="section-profile" class="section">
-    <div class="page-header"><h2>내 프로필</h2></div>
+    <div class="page-header"><h2>내 프로필</h2><p>로그인된 유저의 프로필 조회 및 수정 API입니다. 모든 요청에 <b>JWT 토큰</b>이 필요합니다.</p></div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
         <h3><span class="method method-get">GET</span>/api/v1/users/me</h3>
       </div>
       <div class="card-body">
+        <div class="api-desc">현재 로그인된 유저의 전체 프로필을 반환합니다. 닉네임, 이메일, 프로필 이미지, 연동 소셜 계정, 즐겨찾는 가수/차단 가수 목록이 포함됩니다.</div>
         <div class="btn-group"><button class="btn-primary" onclick="getMe()">조회</button></div>
         <div id="me-display" style="display:none;margin-top:14px">
           <div class="flex-center" style="margin-bottom:12px">
@@ -290,6 +306,7 @@
         <h3><span class="method method-patch">PATCH</span>/api/v1/users/me/profile</h3>
       </div>
       <div class="card-body">
+        <div class="api-desc">프로필을 수정합니다. <b>변경할 필드만 입력</b>하면 됩니다 (나머지는 유지). 이미지는 multipart/form-data로 전송됩니다.</div>
         <div class="form-grid">
           <div class="form-row">
             <label>닉네임 (1~20자)</label>
@@ -312,13 +329,14 @@
 
   <!-- ── BLOCKED ── -->
   <div id="section-blocked" class="section">
-    <div class="page-header"><h2>차단 관리</h2></div>
+    <div class="page-header"><h2>차단 관리</h2><p>특정 가수 또는 곡을 차단하면 추천 결과에서 제외됩니다.</p></div>
     <!-- 차단 가수 -->
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3>차단 가수</h3><span class="method method-get">GET</span>
+        <h3><span class="method method-get">GET</span><span class="method method-post">POST</span><span class="method method-delete">DELETE</span>&nbsp;차단 가수 관리</h3>
       </div>
       <div class="card-body">
+        <div class="api-desc">차단된 가수는 추천/랜덤 조회에서 제외됩니다. <code>singer_id</code>는 <b>가수 검색 탭</b>에서 확인할 수 있습니다.</div>
         <div class="btn-group" style="margin-bottom:10px">
           <button class="btn-blue" onclick="getBlockedSingers()">목록 조회</button>
         </div>
@@ -326,8 +344,8 @@
         <hr class="divider">
         <div class="form-grid">
           <div class="form-row">
-            <label>가수 ID (UUID) 차단</label>
-            <input type="text" id="block-singer-id" placeholder="singer_id UUID">
+            <label>가수 ID <span class="required">*</span><span class="field-hint">가수 검색 탭에서 조회 후 singer_id 복사</span></label>
+            <input type="text" id="block-singer-id" placeholder="singer_id (정수)">
           </div>
         </div>
         <div class="btn-group">
@@ -339,9 +357,10 @@
     <!-- 차단 곡 -->
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3>차단 곡</h3><span class="method method-get">GET</span>
+        <h3><span class="method method-get">GET</span><span class="method method-post">POST</span><span class="method method-delete">DELETE</span>&nbsp;차단 곡 관리</h3>
       </div>
       <div class="card-body">
+        <div class="api-desc">차단된 곡은 추천 결과에서 제외됩니다. <code>song_id</code>는 내부 DB의 <b>UUID</b>입니다 (Spotify URI 아님).</div>
         <div class="btn-group" style="margin-bottom:10px">
           <button class="btn-blue" onclick="getBlockedSongs()">목록 조회</button>
         </div>
@@ -349,7 +368,7 @@
         <hr class="divider">
         <div class="form-grid">
           <div class="form-row">
-            <label>곡 ID (UUID) 차단</label>
+            <label>곡 ID <span class="required">*</span><span class="field-hint">내부 DB song UUID</span></label>
             <input type="text" id="block-song-id" placeholder="song_id UUID">
           </div>
         </div>
@@ -363,14 +382,15 @@
 
   <!-- ── SINGERS ── -->
   <div id="section-singers" class="section">
-    <div class="page-header"><h2>가수 검색</h2></div>
+    <div class="page-header"><h2>가수 검색</h2><p>내부 DB에 등록된 가수를 검색합니다. 온보딩 및 추천 시스템에서 사용하는 데이터입니다.</p></div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
         <h3><span class="method method-get">GET</span>/api/v1/singers/search</h3>
       </div>
       <div class="card-body">
+        <div class="api-desc">가수 이름 또는 별칭으로 부분 검색합니다. 반환되는 <code>singer_id</code>를 차단/즐겨찾기에 사용합니다.</div>
         <div class="flex-center">
-          <input type="text" id="singer-query" placeholder="가수 이름 검색..." style="flex:1">
+          <input type="text" id="singer-query" placeholder="가수 이름 검색... (ex: 아이유, IU)" style="flex:1">
           <button class="btn-primary" onclick="searchSingers()" style="flex-shrink:0">검색</button>
         </div>
         <div class="response-box" id="singer-response" style="display:none;margin-top:12px"></div>
@@ -381,7 +401,8 @@
         <h3><span class="method method-get">GET</span>/api/v1/singers/random</h3>
       </div>
       <div class="card-body">
-        <div class="btn-group"><button class="btn-primary" onclick="randomSingers()">랜덤 가수 조회</button></div>
+        <div class="api-desc">성별 필터 없이 호출하면 <b>남자 6명 + 여자 6명</b> 기본 반환. <code>gender=male</code> 또는 <code>gender=female</code> 지정 시 해당 성별만 반환. 차단된 가수는 자동 제외됩니다.</div>
+        <div class="btn-group"><button class="btn-primary" onclick="randomSingers()">랜덤 가수 조회 (남6+여6)</button></div>
         <div class="response-box" id="random-singer-response" style="display:none;margin-top:12px"></div>
       </div>
     </div>
@@ -389,14 +410,15 @@
 
   <!-- ── SONGS ── -->
   <div id="section-songs" class="section">
-    <div class="page-header"><h2>곡 검색</h2></div>
+    <div class="page-header"><h2>곡 검색</h2><p>Spotify API로 곡을 검색합니다. 검색 결과에서 [찜] 또는 [기록] 버튼으로 라이브러리에 바로 추가할 수 있습니다.</p></div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
         <h3><span class="method method-get">GET</span>/api/v1/music/search</h3>
       </div>
       <div class="card-body">
+        <div class="api-desc">Spotify에서 곡을 검색합니다. 반환 데이터: <code>{ name, artist, album_image, uri }</code>. 이 <code>song_data</code>를 그대로 찜/가창기록에 저장합니다. <b>내부 song DB와는 별개</b>입니다.</div>
         <div class="flex-center">
-          <input type="text" id="song-query" placeholder="곡 제목 또는 가수 검색..." style="flex:1">
+          <input type="text" id="song-query" placeholder="곡 제목 또는 가수 검색... (ex: 팔레트 아이유)" style="flex:1">
           <button class="btn-primary" onclick="searchSongs()" style="flex-shrink:0">검색</button>
         </div>
         <div id="song-results" style="margin-top:12px"></div>
@@ -407,12 +429,13 @@
 
   <!-- ── BUSKING ROOMS ── -->
   <div id="section-busking-rooms" class="section">
-    <div class="page-header"><h2>버스킹 방 목록 / 생성</h2></div>
+    <div class="page-header"><h2>버스킹 방 목록 / 생성</h2><p>온라인 버스킹 라이브 세션을 관리합니다. 방 생성 → 라이브 시작 → 진행 → 종료 순서입니다.</p></div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
         <h3><span class="method method-get">GET</span>/api/v1/busking/rooms</h3>
       </div>
       <div class="card-body">
+        <div class="api-desc">현재 생성된 버스킹 방 목록을 반환합니다. 상태: <code>PREPARING</code> (라이브 전) / <code>LIVE</code> (진행 중) / <code>ENDED</code> (종료)</div>
         <div class="btn-group" style="margin-bottom:12px">
           <button class="btn-primary" onclick="getRooms()">새로고침</button>
         </div>
@@ -424,8 +447,9 @@
         <h3><span class="method method-post">POST</span>/api/v1/busking/rooms — 방 생성</h3>
       </div>
       <div class="card-body">
+        <div class="api-desc">버스킹 방을 생성합니다. 생성 직후 상태는 <code>PREPARING</code>이며, <b>방 제어 탭</b>에서 라이브 시작을 눌러야 LiveKit 세션이 열립니다. 셋리스트는 <b>곡 검색 탭</b>에서 검색 후 입력하세요.</div>
         <div class="form-row">
-          <label>방 제목</label>
+          <label>방 제목 <span class="required">*</span></label>
           <input type="text" id="room-title" placeholder="오늘의 버스킹">
         </div>
         <div class="form-row">
@@ -433,7 +457,7 @@
           <input type="text" id="room-thumbnail" placeholder="https://...">
         </div>
         <div class="form-row">
-          <label>셋리스트 (3~5곡) — Spotify에서 검색한 곡 정보 입력</label>
+          <label>셋리스트 <span class="required">*</span> <span class="field-hint">곡 검색에서 찾은 name·artist·album_image·uri 입력 (3~5곡)</span></label>
           <div id="setlist-items"></div>
           <button class="btn-outline btn-sm" onclick="addSetlistItem()" style="margin-top:6px">+ 곡 추가</button>
         </div>
@@ -447,63 +471,69 @@
 
   <!-- ── BUSKING CTRL ── -->
   <div id="section-busking-ctrl" class="section">
-    <div class="page-header"><h2>방 제어</h2></div>
+    <div class="page-header"><h2>방 제어</h2><p>방 목록에서 복사한 Room ID를 아래에 입력하면 모든 제어 API를 테스트할 수 있습니다.</p></div>
     <div class="form-row" style="max-width:400px;margin-bottom:20px">
-      <label>Room ID (UUID)</label>
+      <label>Room ID <span class="required">*</span> <span class="field-hint">방 목록/생성 탭에서 방 생성 후 반환된 UUID</span></label>
       <input type="text" id="ctrl-room-id" placeholder="방 UUID를 입력하세요">
     </div>
     <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
       <div class="card">
         <div class="card-header" onclick="toggleCard(this)">
-          <h3><span class="method method-get">GET</span>방 상세</h3>
+          <h3><span class="method method-get">GET</span>/api/v1/busking/rooms/{id}</h3>
         </div>
         <div class="card-body">
+          <div class="api-desc">방 상세 정보 조회. 셋리스트, 현재 곡 인덱스, 참여자 수, 상태를 반환합니다.</div>
           <div class="btn-group"><button class="btn-primary" onclick="getRoom()">조회</button></div>
           <div class="response-box" id="get-room-response" style="display:none"></div>
         </div>
       </div>
       <div class="card">
         <div class="card-header" onclick="toggleCard(this)">
-          <h3><span class="method method-post">POST</span>라이브 시작</h3>
+          <h3><span class="method method-post">POST</span>/api/v1/busking/rooms/{id}/start</h3>
         </div>
         <div class="card-body">
-          <div class="btn-group"><button class="btn-green" onclick="startRoom()">시작</button></div>
+          <div class="api-desc">라이브를 시작합니다. LiveKit Room이 생성되고 호스트 토큰이 반환됩니다. 상태가 <code>LIVE</code>로 변경됩니다. <b>방 생성자만 가능</b>합니다.</div>
+          <div class="btn-group"><button class="btn-green" onclick="startRoom()">라이브 시작</button></div>
           <div class="response-box" id="start-room-response" style="display:none"></div>
         </div>
       </div>
       <div class="card">
         <div class="card-header" onclick="toggleCard(this)">
-          <h3><span class="method method-post">POST</span>뷰어 입장 토큰</h3>
+          <h3><span class="method method-post">POST</span>/api/v1/busking/rooms/{id}/join</h3>
         </div>
         <div class="card-body">
-          <div class="btn-group"><button class="btn-blue" onclick="joinRoom()">토큰 발급</button></div>
+          <div class="api-desc">뷰어용 LiveKit 토큰을 발급합니다. 이 토큰으로 LiveKit SDK에 연결하면 오디오를 수신할 수 있습니다 (publish 권한 없음).</div>
+          <div class="btn-group"><button class="btn-blue" onclick="joinRoom()">뷰어 토큰 발급</button></div>
           <div class="response-box" id="join-room-response" style="display:none"></div>
         </div>
       </div>
       <div class="card">
         <div class="card-header" onclick="toggleCard(this)">
-          <h3><span class="method method-patch">PATCH</span>다음 곡</h3>
+          <h3><span class="method method-patch">PATCH</span>/api/v1/busking/rooms/{id}/next-song</h3>
         </div>
         <div class="card-body">
-          <div class="btn-group"><button class="btn-primary" onclick="nextSong()">Next Song</button></div>
+          <div class="api-desc">셋리스트의 다음 곡으로 넘어갑니다. WebSocket으로 연결된 모든 뷰어에게 <code>SONG_CHANGED</code> 이벤트가 전송됩니다. <b>호스트 전용</b>.</div>
+          <div class="btn-group"><button class="btn-primary" onclick="nextSong()">다음 곡</button></div>
           <div class="response-box" id="next-song-response" style="display:none"></div>
         </div>
       </div>
       <div class="card">
         <div class="card-header" onclick="toggleCard(this)">
-          <h3><span class="method method-post">POST</span>라이브 종료</h3>
+          <h3><span class="method method-post">POST</span>/api/v1/busking/rooms/{id}/end</h3>
         </div>
         <div class="card-body">
-          <div class="btn-group"><button class="btn-red" onclick="endRoom()">종료</button></div>
+          <div class="api-desc">라이브를 종료합니다. LiveKit Room이 삭제되고 상태가 <code>ENDED</code>로 변경됩니다. 종료 후 결과(reaction 집계) 조회가 가능합니다.</div>
+          <div class="btn-group"><button class="btn-red" onclick="endRoom()">라이브 종료</button></div>
           <div class="response-box" id="end-room-response" style="display:none"></div>
         </div>
       </div>
       <div class="card">
         <div class="card-header" onclick="toggleCard(this)">
-          <h3><span class="method method-get">GET</span>결과 조회</h3>
+          <h3><span class="method method-get">GET</span>/api/v1/busking/rooms/{id}/result</h3>
         </div>
         <div class="card-body">
-          <div class="btn-group"><button class="btn-primary" onclick="getResult()">결과</button></div>
+          <div class="api-desc">라이브 종료 후 결과를 조회합니다. 곡별 match/mismatch 리액션 수, 총 채팅 수 등이 포함됩니다.</div>
+          <div class="btn-group"><button class="btn-primary" onclick="getResult()">결과 조회</button></div>
           <div class="response-box" id="result-response" style="display:none"></div>
         </div>
       </div>
@@ -512,14 +542,19 @@
 
   <!-- ── BUSKING WS ── -->
   <div id="section-busking-ws" class="section">
-    <div class="page-header"><h2>WebSocket 테스트</h2></div>
+    <div class="page-header"><h2>WebSocket 테스트</h2><p>버스킹 실시간 채팅 및 리액션 WebSocket 연결 테스트입니다. 라이브 중인 방에서만 동작합니다.</p></div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
         <h3><span class="method method-ws">WS</span>/api/v1/busking/ws/{room_id}</h3>
       </div>
       <div class="card-body">
+        <div class="api-desc">
+          <b>연결 조건:</b> 방이 <code>LIVE</code> 상태여야 합니다. JWT 토큰은 URL 쿼리 파라미터 <code>?token=...</code>으로 전달됩니다.<br>
+          <b>수신 이벤트:</b> <code>CHAT</code> · <code>REACTION</code> · <code>SONG_CHANGED</code> · <code>ROOM_ENDED</code><br>
+          <b>전송 가능 메시지:</b> <code>{"type":"chat","message":"..."}</code> · <code>{"type":"reaction","reaction_type":"match"}</code>
+        </div>
         <div class="form-row">
-          <label>Room ID (UUID)</label>
+          <label>Room ID <span class="required">*</span> <span class="field-hint">LIVE 상태인 방의 UUID</span></label>
           <input type="text" id="ws-room-id" placeholder="버스킹 방 UUID">
         </div>
         <div class="btn-group" style="margin-bottom:12px">
@@ -551,8 +586,13 @@
         <h3><span class="method method-post">POST</span>/api/v1/users/me/onboarding/step1 — 닉네임·사진 설정</h3>
       </div>
       <div class="card-body">
-        <div class="form-row"><label>닉네임 *</label><input type="text" id="ob1-nickname" placeholder="닉네임 (1~20자)"></div>
-        <div class="form-row"><label>프로필 사진</label><input type="file" id="ob1-image" accept="image/jpeg,image/png,image/webp"></div>
+        <div class="api-desc">
+          신규 유저 닉네임과 프로필 사진을 설정합니다. <code>multipart/form-data</code>로 전송됩니다.<br>
+          • <code>nickname</code> <span class="required">*필수</span> — 1~20자 문자열<br>
+          • <code>profile_image</code> — JPEG / PNG / WebP 이미지 파일 (선택)
+        </div>
+        <div class="form-row"><label>닉네임 <span class="required">*</span></label><input type="text" id="ob1-nickname" placeholder="닉네임 (1~20자)"></div>
+        <div class="form-row"><label>프로필 사진</label><input type="file" id="ob1-image" accept="image/jpeg,image/png,image/webp"><div class="field-hint">JPEG · PNG · WebP 지원 / 없으면 비워두세요</div></div>
         <div class="btn-group"><button class="btn-primary" onclick="onboardingStep1()">저장</button></div>
         <div class="response-box" id="ob1-response" style="display:none"></div>
       </div>
@@ -562,7 +602,11 @@
         <h3><span class="method method-post">POST</span>/api/v1/users/me/onboarding/step2 — 즐겨부르는 가수 선택</h3>
       </div>
       <div class="card-body">
-        <div class="form-row"><label>Singer IDs</label><input type="text" id="ob2-singer-ids" placeholder="쉼표 구분 ex) 1,2,3"></div>
+        <div class="api-desc">
+          유저가 좋아하는 가수를 선택해 프로필에 저장합니다. 추천 시스템의 초기 선호 데이터로 활용됩니다.<br>
+          • <code>singer_ids</code> <span class="required">*필수</span> — 가수 조회 탭에서 확인한 정수 ID 목록 (쉼표로 구분)
+        </div>
+        <div class="form-row"><label>Singer IDs <span class="required">*</span></label><input type="text" id="ob2-singer-ids" placeholder="쉼표 구분 ex) 1,2,3"><div class="field-hint">가수 탭에서 ID를 먼저 확인하세요</div></div>
         <div class="btn-group"><button class="btn-primary" onclick="onboardingStep2()">저장</button></div>
         <div class="response-box" id="ob2-response" style="display:none"></div>
       </div>
@@ -574,9 +618,12 @@
     <div class="page-header"><h2>폴더</h2></div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3><span class="method method-get">GET</span>/api/v1/library/folders</h3>
+        <h3><span class="method method-get">GET</span>/api/v1/library/folders — 내 폴더 목록</h3>
       </div>
       <div class="card-body">
+        <div class="api-desc">
+          로그인된 유저의 모든 보관함 폴더를 반환합니다. 별도 파라미터 없음.
+        </div>
         <div class="btn-group"><button class="btn-primary" onclick="getFolders()">조회</button></div>
         <div class="response-box" id="folders-list-response" style="display:none"></div>
       </div>
@@ -586,17 +633,25 @@
         <h3><span class="method method-post">POST</span>/api/v1/library/folders — 폴더 생성</h3>
       </div>
       <div class="card-body">
-        <div class="form-row"><label>폴더명</label><input type="text" id="folder-name" placeholder="폴더 이름"></div>
+        <div class="api-desc">
+          새 폴더를 생성합니다.<br>
+          • <code>name</code> <span class="required">*필수</span> — 폴더 이름 문자열
+        </div>
+        <div class="form-row"><label>폴더명 <span class="required">*</span></label><input type="text" id="folder-name" placeholder="폴더 이름"></div>
         <div class="btn-group"><button class="btn-primary" onclick="createFolder()">생성</button></div>
         <div class="response-box" id="folder-create-response" style="display:none"></div>
       </div>
     </div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3><span class="method method-delete">DELETE</span>/api/v1/library/folders/{id}</h3>
+        <h3><span class="method method-delete">DELETE</span>/api/v1/library/folders/{id} — 폴더 삭제</h3>
       </div>
       <div class="card-body">
-        <div class="form-row"><label>폴더 ID</label><input type="text" id="folder-delete-id" placeholder="UUID"></div>
+        <div class="api-desc">
+          폴더를 삭제합니다. 폴더 안의 찜 항목은 <strong>함께 삭제</strong>되므로 주의하세요.<br>
+          • <code>id</code> <span class="required">*필수</span> — 위 목록 조회에서 확인한 폴더 UUID
+        </div>
+        <div class="form-row"><label>폴더 ID <span class="required">*</span></label><input type="text" id="folder-delete-id" placeholder="UUID"><div class="field-hint">GET 폴더 목록에서 id 값을 복사하세요</div></div>
         <div class="btn-group"><button class="btn-red" onclick="deleteFolder()">삭제</button></div>
         <div class="response-box" id="folder-delete-response" style="display:none"></div>
       </div>
@@ -608,10 +663,14 @@
     <div class="page-header"><h2>찜 (Wishlist)</h2></div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3><span class="method method-get">GET</span>/api/v1/library/wishlist</h3>
+        <h3><span class="method method-get">GET</span>/api/v1/library/wishlist — 찜 목록 조회</h3>
       </div>
       <div class="card-body">
-        <div class="form-row"><label>folder_id (선택)</label><input type="text" id="wishlist-folder-id" placeholder="UUID"></div>
+        <div class="api-desc">
+          유저의 찜 목록을 반환합니다.<br>
+          • <code>folder_id</code> — UUID 입력 시 해당 폴더 항목만 필터링 (비워두면 전체 조회)
+        </div>
+        <div class="form-row"><label>folder_id (선택)</label><input type="text" id="wishlist-folder-id" placeholder="UUID (비워두면 전체 조회)"></div>
         <div class="btn-group"><button class="btn-primary" onclick="getWishlist()">조회</button></div>
         <div class="response-box" id="wishlist-list-response" style="display:none"></div>
       </div>
@@ -621,19 +680,27 @@
         <h3><span class="method method-post">POST</span>/api/v1/library/wishlist — 찜 추가</h3>
       </div>
       <div class="card-body">
-        <p style="font-size:12px;color:#888;margin-bottom:8px">곡 검색 탭에서 [찜] 버튼을 누르거나, 아래에 JSON 직접 입력</p>
-        <div class="form-row"><label>song_data (JSON)</label><textarea id="wishlist-song-data" rows="3" placeholder='{"name":"Palette","artist":"IU","album_image":"https://...","uri":"spotify:track:..."}'></textarea></div>
-        <div class="form-row"><label>folder_id (선택)</label><input type="text" id="wishlist-add-folder-id" placeholder="UUID"></div>
+        <div class="api-desc">
+          곡을 찜 목록에 추가합니다. 곡 검색 탭의 [찜] 버튼을 이용하거나 아래에 직접 입력하세요.<br>
+          • <code>song_data</code> <span class="required">*필수</span> — Spotify 곡 정보 JSON: <code>name</code>, <code>artist</code>, <code>album_image</code>, <code>uri</code><br>
+          • <code>folder_id</code> — 특정 폴더에 넣으려면 폴더 UUID 입력 (선택)
+        </div>
+        <div class="form-row"><label>song_data (JSON) <span class="required">*</span></label><textarea id="wishlist-song-data" rows="3" placeholder='{"name":"Palette","artist":"IU","album_image":"https://...","uri":"spotify:track:..."}'></textarea></div>
+        <div class="form-row"><label>folder_id (선택)</label><input type="text" id="wishlist-add-folder-id" placeholder="UUID (없으면 비워두세요)"></div>
         <div class="btn-group"><button class="btn-primary" onclick="addWishlist()">찜 추가</button></div>
         <div class="response-box" id="wishlist-add-response" style="display:none"></div>
       </div>
     </div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3><span class="method method-delete">DELETE</span>/api/v1/library/wishlist/{item_id}</h3>
+        <h3><span class="method method-delete">DELETE</span>/api/v1/library/wishlist/{item_id} — 찜 해제</h3>
       </div>
       <div class="card-body">
-        <div class="form-row"><label>item_id</label><input type="text" id="wishlist-delete-id" placeholder="UUID"></div>
+        <div class="api-desc">
+          찜 항목을 삭제합니다.<br>
+          • <code>item_id</code> <span class="required">*필수</span> — GET 찜 목록에서 확인한 항목 UUID
+        </div>
+        <div class="form-row"><label>item_id <span class="required">*</span></label><input type="text" id="wishlist-delete-id" placeholder="UUID"><div class="field-hint">GET 찜 목록 응답의 id 값을 복사하세요</div></div>
         <div class="btn-group"><button class="btn-red" onclick="deleteWishlist()">찜 해제</button></div>
         <div class="response-box" id="wishlist-delete-response" style="display:none"></div>
       </div>
@@ -645,45 +712,63 @@
     <div class="page-header"><h2>가창 기록</h2></div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3><span class="method method-get">GET</span>/api/v1/library/history</h3>
+        <h3><span class="method method-get">GET</span>/api/v1/library/history — 가창 기록 목록</h3>
       </div>
       <div class="card-body">
-        <div class="form-row"><label>tag 필터 (선택)</label><input type="text" id="history-tag" placeholder="ex) AGAIN"></div>
+        <div class="api-desc">
+          유저의 가창 기록 목록을 반환합니다. 최신순으로 정렬됩니다.<br>
+          • <code>tag</code> — <code>AGAIN</code> / <code>COMFORTABLE</code> / <code>PRACTICE</code> 등 태그로 필터링 (선택)
+        </div>
+        <div class="form-row"><label>tag 필터 (선택)</label><input type="text" id="history-tag" placeholder="AGAIN / COMFORTABLE / PRACTICE"><div class="field-hint">비워두면 전체 기록 조회</div></div>
         <div class="btn-group"><button class="btn-primary" onclick="getHistory()">조회</button></div>
         <div class="response-box" id="history-list-response" style="display:none"></div>
       </div>
     </div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3><span class="method method-post">POST</span>/api/v1/library/history — 기록 저장</h3>
+        <h3><span class="method method-post">POST</span>/api/v1/library/history — 가창 기록 저장</h3>
       </div>
       <div class="card-body">
-        <p style="font-size:12px;color:#888;margin-bottom:8px">곡 검색 탭에서 [기록] 버튼을 누르거나, 아래에 JSON 직접 입력</p>
-        <div class="form-row"><label>song_data (JSON)</label><textarea id="history-song-data" rows="3" placeholder='{"name":"Palette","artist":"IU","album_image":"https://...","uri":"spotify:track:..."}'></textarea></div>
-        <div class="form-row"><label>tags (쉼표 구분)</label><input type="text" id="history-tags" placeholder="AGAIN,COMFORTABLE"></div>
-        <div class="form-row"><label>memo</label><input type="text" id="history-memo" placeholder="메모 (선택)"></div>
+        <div class="api-desc">
+          곡을 가창 기록에 저장합니다. 곡 검색 탭의 [기록] 버튼을 사용하거나 아래에 직접 입력하세요.<br>
+          • <code>song_data</code> <span class="required">*필수</span> — Spotify 곡 정보 JSON: <code>name</code>, <code>artist</code>, <code>album_image</code>, <code>uri</code><br>
+          • <code>tags</code> — 가창 태그 목록 (쉼표 구분, ex: <code>AGAIN,COMFORTABLE</code>), 선택<br>
+          • <code>memo</code> — 자유 메모 (선택)
+        </div>
+        <div class="form-row"><label>song_data (JSON) <span class="required">*</span></label><textarea id="history-song-data" rows="3" placeholder='{"name":"Palette","artist":"IU","album_image":"https://...","uri":"spotify:track:..."}'></textarea></div>
+        <div class="form-row"><label>tags (쉼표 구분)</label><input type="text" id="history-tags" placeholder="AGAIN,COMFORTABLE"><div class="field-hint">사용 가능한 태그: AGAIN · COMFORTABLE · PRACTICE · CHALLENGE</div></div>
+        <div class="form-row"><label>memo (선택)</label><input type="text" id="history-memo" placeholder="메모 (선택)"></div>
         <div class="btn-group"><button class="btn-primary" onclick="createHistory()">저장</button></div>
         <div class="response-box" id="history-create-response" style="display:none"></div>
       </div>
     </div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3><span class="method method-patch">PATCH</span>/api/v1/library/history/{id} — 수정</h3>
+        <h3><span class="method method-patch">PATCH</span>/api/v1/library/history/{id} — 가창 기록 수정</h3>
       </div>
       <div class="card-body">
-        <div class="form-row"><label>archive_id *</label><input type="text" id="history-patch-id" placeholder="UUID"></div>
-        <div class="form-row"><label>tags</label><input type="text" id="history-patch-tags" placeholder="AGAIN,PRACTICE"></div>
-        <div class="form-row"><label>memo</label><input type="text" id="history-patch-memo" placeholder="수정된 메모"></div>
+        <div class="api-desc">
+          기존 가창 기록의 태그 또는 메모를 수정합니다. 변경하고 싶은 필드만 입력하면 됩니다 (부분 업데이트).<br>
+          • <code>id</code> <span class="required">*필수</span> — 수정할 기록의 UUID<br>
+          • <code>tags</code> / <code>memo</code> — 변경할 값 (선택)
+        </div>
+        <div class="form-row"><label>archive_id <span class="required">*</span></label><input type="text" id="history-patch-id" placeholder="UUID"><div class="field-hint">GET 기록 목록 응답의 id 값</div></div>
+        <div class="form-row"><label>tags (선택)</label><input type="text" id="history-patch-tags" placeholder="AGAIN,PRACTICE"></div>
+        <div class="form-row"><label>memo (선택)</label><input type="text" id="history-patch-memo" placeholder="수정된 메모"></div>
         <div class="btn-group"><button class="btn-primary" onclick="updateHistory()">수정</button></div>
         <div class="response-box" id="history-patch-response" style="display:none"></div>
       </div>
     </div>
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3><span class="method method-delete">DELETE</span>/api/v1/library/history/{id}</h3>
+        <h3><span class="method method-delete">DELETE</span>/api/v1/library/history/{id} — 가창 기록 삭제</h3>
       </div>
       <div class="card-body">
-        <div class="form-row"><label>archive_id</label><input type="text" id="history-delete-id" placeholder="UUID"></div>
+        <div class="api-desc">
+          가창 기록을 삭제합니다.<br>
+          • <code>id</code> <span class="required">*필수</span> — GET 기록 목록에서 확인한 UUID
+        </div>
+        <div class="form-row"><label>archive_id <span class="required">*</span></label><input type="text" id="history-delete-id" placeholder="UUID"><div class="field-hint">GET 기록 목록 응답의 id 값을 복사하세요</div></div>
         <div class="btn-group"><button class="btn-red" onclick="deleteHistory()">삭제</button></div>
         <div class="response-box" id="history-delete-response" style="display:none"></div>
       </div>
@@ -691,35 +776,207 @@
   </div>
 
   <!-- ── RECOMMENDATION ── -->
-  <div id="section-recommendation" class="section">
-    <div class="page-header"><h2>추천 분석</h2></div>
+  <!-- ── ANALYSIS ── -->
+  <div id="section-analysis" class="section">
+    <div class="page-header"><h2>보컬 분석 파이프라인</h2><p class="text-sm" style="color:var(--text2);margin-top:4px">녹음 파일을 S3에 업로드하고 AI 워커가 보컬을 분석합니다. 분석 완료 후 추천 파이프라인에서 프로필을 사용합니다.</p></div>
+
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3><span class="method method-post">POST</span>/api/v1/recommendations/upload-url — [1] S3 업로드 URL</h3>
+        <h3><span class="method method-post">POST</span>/api/v1/analysis/upload-url &nbsp;<small style="color:var(--text2);font-weight:400">[1단계] S3 presigned PUT URL 발급</small></h3>
       </div>
       <div class="card-body">
-        <div class="btn-group"><button class="btn-primary" onclick="getUploadUrl()">URL 발급</button></div>
-        <div class="response-box" id="rec-upload-response" style="display:none"></div>
+        <p class="text-sm" style="color:var(--text2);margin-bottom:12px">이 URL로 프론트엔드가 S3에 직접 오디오 파일을 업로드합니다. 반환된 <code>s3_key</code>를 다음 단계에서 사용합니다.</p>
+        <div class="btn-group"><button class="btn-primary" onclick="getAnalysisUploadUrl()">URL 발급</button></div>
+        <div class="response-box" id="analysis-upload-response" style="display:none"></div>
       </div>
     </div>
+
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3><span class="method method-post">POST</span>/api/v1/recommendations/start — [2] 분석 시작</h3>
+        <h3><span class="method method-post">POST</span>/api/v1/analysis/jobs &nbsp;<small style="color:var(--text2);font-weight:400">[2단계] 분석 Job 생성 + SQS 전송</small></h3>
       </div>
       <div class="card-body">
-        <div class="form-row"><label>s3_key</label><input type="text" id="rec-s3-key" placeholder="voices/uuid.wav"></div>
-        <div class="btn-group"><button class="btn-primary" onclick="startRec()">시작</button></div>
+        <p class="text-sm" style="color:var(--text2);margin-bottom:12px">S3 업로드 완료 후 호출. DB에 analysis_job을 생성하고 vocal SQS 큐에 <code>{ job_id, s3_key }</code>를 전송합니다. AI 워커가 메시지를 받아 분석을 시작합니다.</p>
+        <div class="form-row">
+          <label>s3_key <span style="color:var(--red)">*</span></label>
+          <input type="text" id="analysis-s3-key" placeholder="recordings/{user_id}/{uuid}.m4a">
+        </div>
+        <div class="form-row">
+          <label>recording_id (선택 — 녹음 레코드 UUID)</label>
+          <input type="text" id="analysis-recording-id" placeholder="UUID (없으면 비워두세요)">
+        </div>
+        <div class="btn-group"><button class="btn-green" onclick="createAnalysisJob()">Job 생성</button></div>
+        <div class="response-box" id="analysis-job-response" style="display:none"></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleCard(this)">
+        <h3><span class="method method-get">GET</span>/api/v1/analysis/jobs/{job_id} &nbsp;<small style="color:var(--text2);font-weight:400">[3단계] 분석 상태 폴링</small></h3>
+      </div>
+      <div class="card-body">
+        <p class="text-sm" style="color:var(--text2);margin-bottom:12px">status: <code>QUEUED → ANALYZING → DONE / FAILED</code>. DONE이면 result_data에 분석 결과가 채워집니다.</p>
+        <div class="form-row">
+          <label>job_id <span style="color:var(--red)">*</span></label>
+          <input type="text" id="analysis-poll-id" placeholder="UUID">
+        </div>
+        <div class="btn-group">
+          <button class="btn-primary" onclick="getAnalysisJob()">조회</button>
+          <button class="btn-outline btn-sm" onclick="startAnalysisPoll()">5초마다 자동 폴링</button>
+          <button class="btn-outline btn-sm" style="color:var(--red);border-color:var(--red)" onclick="stopPoll('analysis')">중지</button>
+        </div>
+        <div class="response-box" id="analysis-poll-response" style="display:none"></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleCard(this)">
+        <h3><span class="method method-get">GET</span>/api/v1/analysis/profile &nbsp;<small style="color:var(--text2);font-weight:400">보컬 프로필 조회</small></h3>
+      </div>
+      <div class="card-body">
+        <p class="text-sm" style="color:var(--text2);margin-bottom:12px">AI 워커가 분석 완료 후 채워넣는 user_vocal_profiles 테이블 데이터. 추천 1차에서 이 프로필을 사용합니다.</p>
+        <div class="btn-group"><button class="btn-blue" onclick="getVocalProfile()">프로필 조회</button></div>
+        <div class="response-box" id="vocal-profile-response" style="display:none"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── RECOMMENDATION ── -->
+  <div id="section-recommendation" class="section">
+    <div class="page-header"><h2>추천 파이프라인</h2><p class="text-sm" style="color:var(--text2);margin-top:4px">보컬 분석 완료 후 진행. 1차 추천(DB 프로필 기반) → 피드백 → 2차 추천(장르/키워드 필터) 순서입니다.</p></div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleCard(this)">
+        <h3><span class="method method-post">POST</span>/api/v1/recommendations &nbsp;<small style="color:var(--text2);font-weight:400">[1단계] 추천 Job 생성 + SQS 전송</small></h3>
+      </div>
+      <div class="card-body">
+        <p class="text-sm" style="color:var(--text2);margin-bottom:12px">recommendation_logs에 Job을 생성하고 SQS에 <code>{ job_id, user_id }</code>를 전송합니다. 워커가 user_vocal_profiles에서 프로필을 읽어 1차 추천을 수행합니다. (s3_key는 FORCE_PIPELINE 폴백 시에만 필요)</p>
+        <div class="form-row">
+          <label>s3_key (선택 — 폴백용)</label>
+          <input type="text" id="rec-s3-key" placeholder="비워두면 DB 프로필 사용">
+        </div>
+        <div class="form-row">
+          <label>base_report_id (선택 — 연관된 analysis_job UUID)</label>
+          <input type="text" id="rec-base-report-id" placeholder="UUID">
+        </div>
+        <div class="btn-group"><button class="btn-green" onclick="startRec()">추천 시작</button></div>
         <div class="response-box" id="rec-start-response" style="display:none"></div>
       </div>
     </div>
+
     <div class="card">
       <div class="card-header" onclick="toggleCard(this)">
-        <h3><span class="method method-get">GET</span>/api/v1/recommendations/{job_id} — [3] 결과 조회</h3>
+        <h3><span class="method method-get">GET</span>/api/v1/recommendations/{job_id} &nbsp;<small style="color:var(--text2);font-weight:400">[2단계] 1차 추천 결과 폴링</small></h3>
       </div>
       <div class="card-body">
-        <div class="form-row"><label>job_id</label><input type="text" id="rec-job-id" placeholder="UUID"></div>
-        <div class="btn-group"><button class="btn-primary" onclick="getRec()">조회</button></div>
+        <p class="text-sm" style="color:var(--text2);margin-bottom:12px">status: <code>QUEUED → RUNNING_STAGE1 → WAITING_FEEDBACK</code>. WAITING_FEEDBACK이 되면 first_recommended_songs에 1차 추천 결과(3곡)가 채워집니다.</p>
+        <div class="form-row">
+          <label>job_id <span style="color:var(--red)">*</span></label>
+          <input type="text" id="rec-job-id" placeholder="UUID">
+        </div>
+        <div class="btn-group">
+          <button class="btn-primary" onclick="getRec()">조회</button>
+          <button class="btn-outline btn-sm" onclick="startRecPoll()">5초마다 자동 폴링</button>
+          <button class="btn-outline btn-sm" style="color:var(--red);border-color:var(--red)" onclick="stopPoll('rec')">중지</button>
+        </div>
         <div class="response-box" id="rec-result-response" style="display:none"></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleCard(this)">
+        <h3><span class="method method-post">POST</span>/api/v1/recommendations/{job_id}/feedback &nbsp;<small style="color:var(--text2);font-weight:400">[3단계] 2차 추천 피드백 전송</small></h3>
+      </div>
+      <div class="card-body">
+        <p class="text-sm" style="color:var(--text2);margin-bottom:12px">1차 추천 결과에서 유저가 선택한 곡 IDs를 전송합니다. 워커가 이 데이터를 읽어 2차 추천을 수행합니다. WAITING_FEEDBACK 상태일 때만 가능합니다.</p>
+        <div class="form-row">
+          <label>job_id <span style="color:var(--red)">*</span></label>
+          <input type="text" id="rec-feedback-job-id" placeholder="UUID">
+        </div>
+        <div class="form-row">
+          <label>reranking_top3 — 선택한 song_id (쉼표 구분, 최대 3개) <span style="color:var(--red)">*</span></label>
+          <input type="text" id="rec-feedback-top3" placeholder="song_uuid1, song_uuid2, song_uuid3">
+        </div>
+        <div class="form-row">
+          <label>selected_genre (선택)</label>
+          <input type="text" id="rec-feedback-genre" placeholder="발라드">
+        </div>
+        <div class="form-row">
+          <label>selected_keyword (선택)</label>
+          <input type="text" id="rec-feedback-keyword" placeholder="감성, 힐링">
+        </div>
+        <div class="btn-group"><button class="btn-primary" onclick="submitFeedback()">피드백 전송</button></div>
+        <div class="response-box" id="rec-feedback-response" style="display:none"></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleCard(this)">
+        <h3><span class="method method-get">GET</span>/api/v1/recommendations/{job_id}/songs &nbsp;<small style="color:var(--text2);font-weight:400">[4단계] 최종 추천 결과 조회</small></h3>
+      </div>
+      <div class="card-body">
+        <p class="text-sm" style="color:var(--text2);margin-bottom:12px">status가 DONE이 되면 recommended_songs에 2차 추천 결과(장르별 최대 4곡)가 채워집니다.</p>
+        <div class="form-row">
+          <label>job_id <span style="color:var(--red)">*</span></label>
+          <input type="text" id="rec-songs-job-id" placeholder="UUID">
+        </div>
+        <div class="btn-group">
+          <button class="btn-blue" onclick="getRecSongs()">최종 결과 조회</button>
+          <button class="btn-outline btn-sm" onclick="startSongsPoll()">5초마다 자동 폴링</button>
+          <button class="btn-outline btn-sm" style="color:var(--red);border-color:var(--red)" onclick="stopPoll('songs')">중지</button>
+        </div>
+        <div class="response-box" id="rec-songs-response" style="display:none"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── ARTIST ACTIONS ── -->
+  <div id="section-artist-actions" class="section">
+    <div class="page-header"><h2>아티스트 액션</h2><p class="text-sm" style="color:var(--text2);margin-top:4px">아티스트 선호/차단 정보. 2차 추천 워커가 이 데이터를 참고해 결과를 필터링합니다.</p></div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleCard(this)">
+        <h3><span class="method method-get">GET</span>/api/v1/artist-actions &nbsp;<small style="color:var(--text2);font-weight:400">내 액션 목록 조회</small></h3>
+      </div>
+      <div class="card-body">
+        <div class="btn-group"><button class="btn-blue" onclick="getArtistActions()">조회</button></div>
+        <div class="response-box" id="artist-list-response" style="display:none"></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleCard(this)">
+        <h3><span class="method method-post">POST</span>/api/v1/artist-actions &nbsp;<small style="color:var(--text2);font-weight:400">PREFER / BLOCK 설정</small></h3>
+      </div>
+      <div class="card-body">
+        <p class="text-sm" style="color:var(--text2);margin-bottom:12px">같은 아티스트에 이미 액션이 있으면 덮어씁니다 (upsert).</p>
+        <div class="form-row">
+          <label>아티스트 이름 <span style="color:var(--red)">*</span></label>
+          <input type="text" id="artist-name-input" placeholder="아이유">
+        </div>
+        <div class="form-row">
+          <label>액션 <span style="color:var(--red)">*</span></label>
+          <select id="artist-action-select">
+            <option value="PREFER">PREFER (선호)</option>
+            <option value="BLOCK">BLOCK (차단)</option>
+          </select>
+        </div>
+        <div class="btn-group"><button class="btn-green" onclick="setArtistAction()">설정</button></div>
+        <div class="response-box" id="artist-set-response" style="display:none"></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleCard(this)">
+        <h3><span class="method method-delete">DELETE</span>/api/v1/artist-actions/{artist_name} &nbsp;<small style="color:var(--text2);font-weight:400">액션 취소</small></h3>
+      </div>
+      <div class="card-body">
+        <div class="form-row">
+          <label>아티스트 이름 <span style="color:var(--red)">*</span></label>
+          <input type="text" id="artist-delete-name" placeholder="아이유">
+        </div>
+        <div class="btn-group"><button class="btn-red" onclick="deleteArtistAction()">취소</button></div>
+        <div class="response-box" id="artist-delete-response" style="display:none"></div>
       </div>
     </div>
   </div>
@@ -1315,25 +1572,126 @@ async function deleteHistory() {
 }
 
 // ═══════════════════════════════════════
+// Analysis
+// ═══════════════════════════════════════
+const _pollTimers = {};
+function stopPoll(key) {
+  if (_pollTimers[key]) { clearInterval(_pollTimers[key]); delete _pollTimers[key]; }
+}
+
+async function getAnalysisUploadUrl() {
+  const { ok, data } = await apiFetch('POST', '/api/v1/analysis/upload-url', {});
+  showResp('analysis-upload-response', data, ok);
+  if (ok && data.s3_key) document.getElementById('analysis-s3-key').value = data.s3_key;
+}
+async function createAnalysisJob() {
+  const s3_key = document.getElementById('analysis-s3-key').value.trim();
+  if (!s3_key) return alert('s3_key를 입력하세요');
+  const body = { s3_key };
+  const rid = document.getElementById('analysis-recording-id').value.trim();
+  if (rid) body.recording_id = rid;
+  const { ok, data } = await apiFetch('POST', '/api/v1/analysis/jobs', body);
+  showResp('analysis-job-response', data, ok);
+  if (ok && data.job_id) document.getElementById('analysis-poll-id').value = data.job_id;
+}
+async function getAnalysisJob() {
+  const id = document.getElementById('analysis-poll-id').value.trim();
+  if (!id) return alert('job_id를 입력하세요');
+  const { ok, data } = await apiFetch('GET', `/api/v1/analysis/jobs/${id}`);
+  showResp('analysis-poll-response', data, ok);
+  return data;
+}
+function startAnalysisPoll() {
+  stopPoll('analysis');
+  _pollTimers['analysis'] = setInterval(async () => {
+    const data = await getAnalysisJob();
+    if (data?.status === 'DONE' || data?.status === 'FAILED') stopPoll('analysis');
+  }, 5000);
+}
+async function getVocalProfile() {
+  const { ok, data } = await apiFetch('GET', '/api/v1/analysis/profile');
+  showResp('vocal-profile-response', data, ok);
+}
+
+// ═══════════════════════════════════════
 // Recommendation
 // ═══════════════════════════════════════
-async function getUploadUrl() {
-  const { ok, data } = await apiFetch('POST', '/api/v1/recommendations/upload-url', {});
-  showResp('rec-upload-response', data, ok);
-  if (ok && data.s3_key) document.getElementById('rec-s3-key').value = data.s3_key;
-}
 async function startRec() {
+  const body = {};
   const s3_key = document.getElementById('rec-s3-key').value.trim();
-  if (!s3_key) return alert('s3_key를 입력하세요');
-  const { ok, data } = await apiFetch('POST', '/api/v1/recommendations/start', { s3_key });
+  if (s3_key) body.s3_key = s3_key;
+  const base = document.getElementById('rec-base-report-id').value.trim();
+  if (base) body.base_report_id = base;
+  const { ok, data } = await apiFetch('POST', '/api/v1/recommendations', body);
   showResp('rec-start-response', data, ok);
-  if (ok && data.job_id) document.getElementById('rec-job-id').value = data.job_id;
+  if (ok && data.job_id) {
+    document.getElementById('rec-job-id').value = data.job_id;
+    document.getElementById('rec-feedback-job-id').value = data.job_id;
+    document.getElementById('rec-songs-job-id').value = data.job_id;
+  }
 }
 async function getRec() {
   const id = document.getElementById('rec-job-id').value.trim();
   if (!id) return alert('job_id를 입력하세요');
   const { ok, data } = await apiFetch('GET', `/api/v1/recommendations/${id}`);
   showResp('rec-result-response', data, ok);
+  return data;
+}
+function startRecPoll() {
+  stopPoll('rec');
+  _pollTimers['rec'] = setInterval(async () => {
+    const data = await getRec();
+    if (data?.status === 'WAITING_FEEDBACK' || data?.status === 'DONE' || data?.status === 'FAILED') stopPoll('rec');
+  }, 5000);
+}
+async function submitFeedback() {
+  const id = document.getElementById('rec-feedback-job-id').value.trim();
+  if (!id) return alert('job_id를 입력하세요');
+  const raw = document.getElementById('rec-feedback-top3').value.trim();
+  if (!raw) return alert('reranking_top3을 입력하세요');
+  const reranking_top3 = raw.split(',').map(s => s.trim()).filter(Boolean);
+  const body = { reranking_top3 };
+  const genre = document.getElementById('rec-feedback-genre').value.trim();
+  const keyword = document.getElementById('rec-feedback-keyword').value.trim();
+  if (genre) body.selected_genre = genre;
+  if (keyword) body.selected_keyword = keyword;
+  const { ok, data } = await apiFetch('POST', `/api/v1/recommendations/${id}/feedback`, body);
+  showResp('rec-feedback-response', data, ok);
+}
+async function getRecSongs() {
+  const id = document.getElementById('rec-songs-job-id').value.trim();
+  if (!id) return alert('job_id를 입력하세요');
+  const { ok, data } = await apiFetch('GET', `/api/v1/recommendations/${id}/songs`);
+  showResp('rec-songs-response', data, ok);
+  return data;
+}
+function startSongsPoll() {
+  stopPoll('songs');
+  _pollTimers['songs'] = setInterval(async () => {
+    const data = await getRecSongs();
+    if (data?.status === 'DONE' || data?.status === 'FAILED') stopPoll('songs');
+  }, 5000);
+}
+
+// ═══════════════════════════════════════
+// Artist Actions
+// ═══════════════════════════════════════
+async function getArtistActions() {
+  const { ok, data } = await apiFetch('GET', '/api/v1/artist-actions');
+  showResp('artist-list-response', data, ok);
+}
+async function setArtistAction() {
+  const artist_name = document.getElementById('artist-name-input').value.trim();
+  if (!artist_name) return alert('아티스트 이름을 입력하세요');
+  const action = document.getElementById('artist-action-select').value;
+  const { ok, data } = await apiFetch('POST', '/api/v1/artist-actions', { artist_name, action });
+  showResp('artist-set-response', data, ok);
+}
+async function deleteArtistAction() {
+  const name = document.getElementById('artist-delete-name').value.trim();
+  if (!name) return alert('아티스트 이름을 입력하세요');
+  const { ok, data } = await apiFetch('DELETE', `/api/v1/artist-actions/${encodeURIComponent(name)}`);
+  showResp('artist-delete-response', data, ok);
 }
 
 // ── storage 이벤트 리스너 (팝업 → 메인창 토큰 수신 fallback) ──


### PR DESCRIPTION
## 📌 Related Issue

- Closes #159 

## 📤 Tasks

- 어드민 페이지 기능 확장

- 보컬 분석 섹션 추가
  - 업로드 URL 발급 → Job 생성 → 자동 폴링 → 프로필 조회

- 추천 파이프라인 섹션 추가
  - 추천 요청 → 1차 결과 폴링 → 피드백 → 최종 결과 조회

- 아티스트 액션 섹션 추가
  - PREFER / BLOCK 설정
  - 목록 조회 및 취소 기능

- UX 개선
  - API별 설명 텍스트 추가 (사용 시점/목적 안내)
  - Job 생성 시 job_id 자동 입력
  - DONE / FAILED / WAITING_FEEDBACK 상태 시 폴링 자동 중지

- 기존 추천 섹션 API 경로 수정


<br/>

## 📸 Screenshot

<!-- admin 페이지 캡처 넣으면 좋음 -->


<br/>

## 💌 To Reviewer

- API 호출 흐름과 상태 기반 폴링 제어 로직 위주로 확인 부탁드립니다.
- admin 페이지에서 전체 파이프라인 테스트가 가능하도록 구성했습니다.