### PR TITLE
Fix(client): 찜 추가 모달에서 삭제하기가 안되는 오류 해결

### DIFF
--- a/frontend/apps/client/src/features/add-favorite/ui/AddFavoriteModal.tsx
+++ b/frontend/apps/client/src/features/add-favorite/ui/AddFavoriteModal.tsx
@@ -8,6 +8,7 @@ import type { SongUiType } from '@/entities/song/model/types';
 
 import { useSearchMusic } from '@/entities/song';
 import { useAddWishlistItem, useDeleteWishlistItem, useWishlist } from '@/entities/library';
+import useDebounce from '@/shared/hooks/useDebounce';
 
 type AddFavoriteModalProps = {
   folderId?: string;
@@ -16,11 +17,12 @@ type AddFavoriteModalProps = {
 
 const AddFavoriteModal = ({ folderId, onClose }: AddFavoriteModalProps) => {
   const [query, setQuery] = useState('');
+  const debouncedQuery = useDebounce(query);
   const [addingIds, setAddingIds] = useState<Set<string>>(() => new Set());
 
   const { mutate: addWishlistItem } = useAddWishlistItem();
   const { mutate: deleteWishlistItem } = useDeleteWishlistItem();
-  const { data: searchedItems = [] } = useSearchMusic(query);
+  const { data: searchedItems = [] } = useSearchMusic(debouncedQuery);
   const { data: wishlistItems = [] } = useWishlist(folderId);
 
   const toggleLike = (song: SongUiType) => {

--- a/frontend/apps/client/src/features/add-favorite/ui/AddFavoriteModal.tsx
+++ b/frontend/apps/client/src/features/add-favorite/ui/AddFavoriteModal.tsx
@@ -7,7 +7,7 @@ import { LikeIconButton, SongListItem } from '@/entities/song/ui';
 import type { SongUiType } from '@/entities/song/model/types';
 
 import { useSearchMusic } from '@/entities/song';
-import { useAddWishlistItem } from '@/entities/library';
+import { useAddWishlistItem, useDeleteWishlistItem, useWishlist } from '@/entities/library';
 
 type AddFavoriteModalProps = {
   folderId?: string;
@@ -16,31 +16,41 @@ type AddFavoriteModalProps = {
 
 const AddFavoriteModal = ({ folderId, onClose }: AddFavoriteModalProps) => {
   const [query, setQuery] = useState('');
-  const [likedIds, setLikedIds] = useState<Set<string>>(() => new Set());
+  const [addingIds, setAddingIds] = useState<Set<string>>(() => new Set());
 
-  const { mutate: addWishlistItem, isPending: isAdding } = useAddWishlistItem();
+  const { mutate: addWishlistItem } = useAddWishlistItem();
+  const { mutate: deleteWishlistItem } = useDeleteWishlistItem();
   const { data: searchedItems = [] } = useSearchMusic(query);
+  const { data: wishlistItems = [] } = useWishlist(folderId);
 
   const toggleLike = (song: SongUiType) => {
     const id = String(song.id);
-    setLikedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-        addWishlistItem({
-          song_data: {
-            name: song.title,
-            artist: song.artist,
-            album_image: song.thumbnail ?? null,
-            uri: id,
-          } as unknown as Record<string, never>,
-          folder_id: folderId,
-        });
-      }
-      return next;
-    });
+    if (addingIds.has(id)) return;
+
+    const existing = wishlistItems.find((item) => item.songId === id);
+    if (existing) {
+      deleteWishlistItem(existing.itemId);
+      return;
+    }
+
+    setAddingIds((prev) => new Set(prev).add(id));
+
+    addWishlistItem(
+      {
+        song_data: {
+          name: song.title,
+          artist: song.artist,
+          album_image: song.thumbnail ?? null,
+          uri: id,
+        } as unknown as Record<string, never>,
+        folder_id: folderId,
+      },
+      {
+        onSettled: () => {
+          setAddingIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
+        },
+      },
+    );
   };
 
   return (
@@ -74,9 +84,9 @@ const AddFavoriteModal = ({ folderId, onClose }: AddFavoriteModalProps) => {
                 thumbnail={song.thumbnail ?? ''}
                 rightSlot={
                   <LikeIconButton
-                    isLiked={likedIds.has(String(song.id))}
+                    isLiked={wishlistItems.some((item) => item.songId === String(song.id))}
                     onClick={() => toggleLike(song)}
-                    disabled={isAdding}
+                    disabled={addingIds.has(String(song.id))}
                   />
                 }
               />

--- a/frontend/apps/client/src/features/add-favorite/ui/AddFolderModal.tsx
+++ b/frontend/apps/client/src/features/add-favorite/ui/AddFolderModal.tsx
@@ -9,6 +9,7 @@ import type { SongUiType } from '@/entities/song/model/types';
 
 import { useSearchMusic } from '@/entities/song';
 import { useCreateFolder, useAddWishlistItem } from '@/entities/library';
+import useDebounce from '@/shared/hooks/useDebounce';
 
 type AddFolderModalProps = {
   onClose: () => void;
@@ -22,7 +23,8 @@ const AddFolderModal = ({ onClose }: AddFolderModalProps) => {
   const { mutate: createFolder, isPending: isCreatingFolder } = useCreateFolder();
   const { mutate: addWishlistItem } = useAddWishlistItem();
 
-  const { data: searchedItems = [] } = useSearchMusic(query);
+  const debouncedQuery = useDebounce(query);
+  const { data: searchedItems = [] } = useSearchMusic(debouncedQuery);
 
   const toggle = (song: SongUiType) => {
     const id = String(song.id);

--- a/frontend/apps/client/src/features/add-history/ui/AddHistoryModal.tsx
+++ b/frontend/apps/client/src/features/add-history/ui/AddHistoryModal.tsx
@@ -11,6 +11,7 @@ import type { HistoryItemUiType } from '@/entities/library';
 
 import { useSearchMusic } from '@/entities/song';
 import { useCreateHistory, useUpdateHistory } from '@/entities/library';
+import useDebounce from '@/shared/hooks/useDebounce';
 
 type AddHistoryModalProps = {
   onClose: () => void;
@@ -44,7 +45,8 @@ const AddHistoryModal = ({ onClose, initialHistory }: AddHistoryModalProps) => {
   const { mutate: updateHistory, isPending: isUpdating } = useUpdateHistory();
   const isPending = isCreating || isUpdating;
 
-  const { data: searchedItems = [] } = useSearchMusic(query);
+  const debouncedQuery = useDebounce(query);
+  const { data: searchedItems = [] } = useSearchMusic(debouncedQuery);
 
   const toggleTag = (key: HistoryTagKeyType) => {
     setSelectedTags((prev) => {

--- a/frontend/apps/client/src/features/busking/ui/LiveStartStep2.tsx
+++ b/frontend/apps/client/src/features/busking/ui/LiveStartStep2.tsx
@@ -9,6 +9,7 @@ import { SongListItem } from '@/entities/song/ui';
 import type { SongUiType } from '@/entities/song/model/types';
 
 import { useSearchMusic } from '@/entities/song';
+import useDebounce from '@/shared/hooks/useDebounce';
 
 const MIN_SETLIST = 3;
 const MAX_SETLIST = 5;
@@ -37,7 +38,8 @@ export const LiveStartStep2 = ({
     [selectedSongs]
   );
 
-  const { data: searchedSongs = [] } = useSearchMusic(keyword);
+  const debouncedKeyword = useDebounce(keyword);
+  const { data: searchedSongs = [] } = useSearchMusic(debouncedKeyword);
 
   const canStart = selectedSongs.length >= MIN_SETLIST;
 

--- a/frontend/apps/client/src/features/record-upload/ui/RecordUploadStep2.tsx
+++ b/frontend/apps/client/src/features/record-upload/ui/RecordUploadStep2.tsx
@@ -10,6 +10,7 @@ import { SongListItem } from '@/entities/song/ui';
 import type { SongUiType } from '@/entities/song/model/types';
 
 import { useSearchMusic } from '@/entities/song';
+import useDebounce from '@/shared/hooks/useDebounce';
 
 const MAX_SETLIST = 1;
 
@@ -43,7 +44,8 @@ export const RecordUploadStep2 = ({
   const dateWrapperRef = useRef<HTMLDivElement>(null);
   useClickOutside(dateWrapperRef, closeDate);
 
-  const { data: searchedSongs = [] } = useSearchMusic(keyword);
+  const debouncedKeyword = useDebounce(keyword);
+  const { data: searchedSongs = [] } = useSearchMusic(debouncedKeyword);
 
   const canSubmit = selectedSongs.length >= 1;
 


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #170


## 📤 Tasks
<!-- 해당 PR에 대한 작업 내용을 작성해주세요. -->
- `AddFavoriteModal`에서 기존 찜 여부를 `wishlistItems` 기준으로 판단하도록 변경했습니다.
- 이미 찜한 곡을 다시 클릭했을 때 삭제 API가 호출되도록 연결했습니다.
- 중복 요청을 방지하기 위해 곡별 `addingIds` 상태를 추가해 처리 중인 항목은 비활성화되도록 반영했습니다.
- 음악 검색이 사용되는 화면에 디바운스를 적용해 불필요한 검색 요청이 반복적으로 발생하지 않도록 개선했습니다.

<br/>
