### PR TITLE
Fix(server): 상태 타입 불일치 및 피드백 검증 로직 수정

### DIFF
--- a/backend/app/models/analysis_job.py
+++ b/backend/app/models/analysis_job.py
@@ -1,7 +1,7 @@
 """AnalysisJob 모델 — 보컬 분석 작업"""
 import uuid
 from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Uuid
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, ENUM
 from sqlalchemy.sql import func
 
 from app.database import Base
@@ -11,11 +11,13 @@ class AnalysisJob(Base):
     __tablename__ = "analysis_jobs"
 
     id = Column(Uuid, primary_key=True, default=uuid.uuid4)
-    recording_id = Column(Uuid, nullable=True)  # DB는 NOT NULL이나 백엔드 생성 시 선택적
+    recording_id = Column(Uuid, nullable=True)
     user_id = Column(Uuid, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    s3_key = Column(String(500), nullable=True)
 
     # status: DB USER-DEFINED enum — QUEUED|UPLOADING|ANALYZING|FINDING_SONGS|DONE|FAILED
-    status = Column(String(30), nullable=False)
+    status = Column(ENUM('QUEUED', 'UPLOADING', 'ANALYZING', 'FINDING_SONGS', 'DONE', 'FAILED',
+                         name='vocal_analysis_status', create_type=False), nullable=False)
 
     # 워커가 채워넣는 분석 결과 { version, result, scoring_song_aligned }
     result_data = Column(JSONB, nullable=True)

--- a/backend/app/models/recommendation.py
+++ b/backend/app/models/recommendation.py
@@ -1,7 +1,7 @@
 """Recommendation 모델 — 추천 파이프라인 로그"""
 import uuid
 from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Uuid
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, ENUM
 from sqlalchemy.sql import func
 
 from app.database import Base
@@ -15,7 +15,8 @@ class Recommendation(Base):
     base_report_id = Column(Uuid, nullable=True)   # analysis_jobs 참조 (선택)
 
     # QUEUED | RUNNING_STAGE1 | WAITING_FEEDBACK | RUNNING_STAGE2 | DONE | FAILED
-    status = Column(String(30), nullable=True)
+    status = Column(ENUM('QUEUED', 'RUNNING_STAGE1', 'WAITING_FEEDBACK', 'RUNNING_STAGE2', 'DONE', 'FAILED',
+                         name='recommendation_status', create_type=False), nullable=True)
 
     # 워커가 채우는 추천 결과 (DB 컬럼명과 일치)
     first_recommended_songs = Column(JSONB, nullable=True)   # 1차 상위 3곡

--- a/backend/app/routers/recommendations.py
+++ b/backend/app/routers/recommendations.py
@@ -80,7 +80,7 @@ async def submit_feedback(
     """
     job = await _get_job_or_404(job_id, current_user.id, db)
 
-    if job.status not in ("WAITING_FEEDBACK", "RUNNING_STAGE1"):
+    if job.status != "WAITING_FEEDBACK":
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={

--- a/backend/app/schemas/recommendation.py
+++ b/backend/app/schemas/recommendation.py
@@ -32,5 +32,5 @@ class RecommendationFeedback(BaseModel):
     워커가 recommendation_logs.input_preferences.reranking_top3 를 읽어 2차 추천에 활용.
     """
     reranking_top3: List[str]
-    selected_genre: Optional[Any] = None    # JSONB — 문자열 또는 객체
-    selected_keyword: Optional[Any] = None  # JSONB — 문자열 또는 객체
+    selected_genre: Optional[List[str]] = None
+    selected_keyword: Optional[List[str]] = None

--- a/backend/app/utils/aws.py
+++ b/backend/app/utils/aws.py
@@ -70,6 +70,7 @@ def send_vocal_sqs_message(message_body: str) -> str | None:
             MessageBody=message_body,
         )
     except ClientError as e:
+        print(e.response)
         print(f"❌ 보컬 SQS 메시지 전송 실패: {e}")
         return None
     return response["MessageId"]


### PR DESCRIPTION
## 📌 Related Issue
- Closes #175 

## 📤 Tasks
- **모델 및 스키마 수정**
  - `backend/app/models/analysis_job.py`: `s3_key` 컬럼 추가 및 status ENUM 타입 일치화
  - `backend/app/models/recommendation.py`: status ENUM 타입 수정
  - `backend/app/schemas/recommendation.py`: `selected_genre/keyword` 타입을 `Any`에서 `List[str]`로 변경하여 타입 안정성 확보
- **로직 보인 및 유효성 검사**
  - `backend/app/routers/recommendations.py`: 피드백 제출 시 현재 상태가 `WAITING_FEEDBACK`인지 확인하는 로직 추가
- **인프라 유틸리티 수정**
  - `backend/app/utils/aws.py`: 보컬 분석용 SQS 메시지 전송 및 처리 로직 보정

<br/>

## 📸 Screenshot
<br/>

## 💌 To Reviewer
- PostgreSQL DB의 ENUM 타입과 Python의 Enum 클래스 간의 불일치로 인한 런타임 에러를 해결했습니다. 
- 특히 `analysis_jobs` 테이블에 `s3_key`가 추가되었으므로 DB 마이그레이션 확인 부탁드립니다.