### PR TITLE
Feat(server): 마이페이지 버스킹 히스토리 및 홈 피드 API 추가

### DIFF
--- a/backend/app/models/song.py
+++ b/backend/app/models/song.py
@@ -21,4 +21,5 @@ class Song(Base):
     raw_s3_key = Column(String, nullable=True)
     download_status = Column(String, nullable=True)
     embedding_status = Column(String, nullable=True)
+    like_count = Column(Integer, nullable=False, server_default="0", default=0)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/routers/home.py
+++ b/backend/app/routers/home.py
@@ -1,0 +1,117 @@
+"""홈 라우터 — 이번주 차트 / 라이브 띠배너"""
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.busking import BuskingRoom
+from app.models.library import WishlistItem
+from app.models.user import User
+
+router = APIRouter(prefix="/api/v1", tags=["Home"])
+
+
+# ── 스키마 ────────────────────────────────────────────
+class WeeklySong(BaseModel):
+    rank: int
+    name: str
+    artist: str
+    album_image: Optional[str] = None
+    uri: Optional[str] = None
+    wish_count: int
+
+class LiveTickerItem(BaseModel):
+    room_id: str
+    title: str
+    thumbnail: Optional[str] = None
+    viewer_count: int
+
+class HomeFeedsResponse(BaseModel):
+    weekly: List[WeeklySong]
+    live_ticker: List[LiveTickerItem]
+
+
+# ── GET /api/v1/home/feeds ────────────────────────────
+@router.get("/home/feeds", response_model=HomeFeedsResponse)
+async def get_home_feeds(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    weekly = await _get_weekly_chart(db)
+    live_ticker = await _get_live_ticker(db)
+    return HomeFeedsResponse(weekly=weekly, live_ticker=live_ticker)
+
+
+# ── GET /api/v1/busking/live-ticker ──────────────────
+@router.get("/busking/live-ticker", response_model=List[LiveTickerItem])
+async def get_live_ticker(
+    db: AsyncSession = Depends(get_db),
+):
+    return await _get_live_ticker(db)
+
+
+# ── 내부 함수 ─────────────────────────────────────────
+async def _get_weekly_chart(db: AsyncSession) -> List[WeeklySong]:
+    since = datetime.now(timezone.utc) - timedelta(days=7)
+
+    result = await db.execute(
+        select(WishlistItem.song_data)
+        .where(WishlistItem.created_at >= since)
+    )
+    rows = result.scalars().all()
+
+    # 이번 주 데이터가 부족하면 전체 기간으로 fallback
+    if len(rows) < 5:
+        result = await db.execute(select(WishlistItem.song_data))
+        rows = result.scalars().all()
+
+    counter: Counter = Counter()
+    song_map: Dict[str, Any] = {}
+
+    for data in rows:
+        if not isinstance(data, dict):
+            continue
+        # uri가 있으면 uri, 없으면 name::artist 로 동일 곡 판별
+        key = data.get("uri") or f"{data.get('name', '')}::{data.get('artist', '')}"
+        if not key or key == "::":
+            continue
+        counter[key] += 1
+        song_map[key] = data
+
+    top5 = counter.most_common(5)
+    return [
+        WeeklySong(
+            rank=i + 1,
+            name=song_map[key].get("name", ""),
+            artist=song_map[key].get("artist", ""),
+            album_image=song_map[key].get("album_image"),
+            uri=song_map[key].get("uri"),
+            wish_count=count,
+        )
+        for i, (key, count) in enumerate(top5)
+    ]
+
+
+async def _get_live_ticker(db: AsyncSession) -> List[LiveTickerItem]:
+    result = await db.execute(
+        select(BuskingRoom)
+        .where(BuskingRoom.status == "LIVE")
+        .order_by(BuskingRoom.total_viewers.desc())
+        .limit(10)
+    )
+    rooms = result.scalars().all()
+    return [
+        LiveTickerItem(
+            room_id=str(r.id),
+            title=r.title,
+            thumbnail=r.thumbnail,
+            viewer_count=r.total_viewers or 0,
+        )
+        for r in rooms
+    ]

--- a/backend/app/routers/user.py
+++ b/backend/app/routers/user.py
@@ -1,13 +1,16 @@
 """유저 라우터"""
 import time
 import uuid
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from pydantic import BaseModel
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.dependencies.auth import get_current_user
+from app.models.busking import BuskingRoom, BuskingSetlistItem, BuskingResult
 from app.models.user import User
 from app.schemas.singer import (
     BlockSingerRequest, BlockedSingerItem, BlockedSingersListResponse,
@@ -339,4 +342,79 @@ async def update_settings(
     return await service.update_settings(
         user_id=current_user.id,
         update_data=update_data,
+    )
+
+
+# ─────────────────────────────────────
+# GET /api/v1/users/me/busking-history
+# ─────────────────────────────────────
+class _SetlistItem(BaseModel):
+    title: str
+    artist: str
+    album_art_url: Optional[str] = None
+    order_index: int
+
+class _BuskingHistoryItem(BaseModel):
+    room_id: str
+    title: str
+    thumbnail: Optional[str] = None
+    status: str
+    started_at: Optional[str] = None
+    ended_at: Optional[str] = None
+    peak_viewer_count: int
+    total_unique_viewers: int
+    setlist: List[_SetlistItem]
+
+class _BuskingHistoryResponse(BaseModel):
+    stats: dict
+    history: List[_BuskingHistoryItem]
+
+@router.get(
+    "/me/busking-history",
+    response_model=_BuskingHistoryResponse,
+    summary="내 버스킹 목록 조회",
+)
+async def get_my_busking_history(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    rooms_result = await db.execute(
+        select(BuskingRoom)
+        .where(BuskingRoom.host_id == current_user.id)
+        .order_by(BuskingRoom.created_at.desc())
+    )
+    rooms = rooms_result.scalars().all()
+
+    history = []
+    for room in rooms:
+        setlist_result = await db.execute(
+            select(BuskingSetlistItem)
+            .where(BuskingSetlistItem.room_id == room.id)
+            .order_by(BuskingSetlistItem.order_index)
+        )
+        setlist = setlist_result.scalars().all()
+
+        history.append(_BuskingHistoryItem(
+            room_id=str(room.id),
+            title=room.title,
+            thumbnail=room.thumbnail,
+            status=room.status,
+            started_at=room.started_at.isoformat() if room.started_at else None,
+            ended_at=room.ended_at.isoformat() if room.ended_at else None,
+            peak_viewer_count=room.peak_viewer_count or 0,
+            total_unique_viewers=room.total_unique_viewers or 0,
+            setlist=[
+                _SetlistItem(
+                    title=s.title,
+                    artist=s.artist,
+                    album_art_url=s.album_art_url,
+                    order_index=s.order_index,
+                )
+                for s in setlist
+            ],
+        ))
+
+    return _BuskingHistoryResponse(
+        stats={"total_lives": len(rooms)},
+        history=history,
     )


### PR DESCRIPTION
## 📌 Related Issue
- Closes #176 

## 📤 Tasks
- **사용자 정보 API 확장**
  - `backend/app/routers/user.py`: 유저의 과거 버스킹 참여 목록 조회 API 추가
- **홈 대시보드 기능 구현**
  - `backend/app/routers/home.py`: 홈 피드 데이터 통합 및 실시간 라이브 띠배너용 데이터 제공 로직 신규 작성
- **도메인 모델 수정**
  - `backend/app/models/song.py`: 추천 시스템의 가중치로 활용될 `like_count` 컬럼 추가

<br/>

## 📸 Screenshot
<br/>

## 💌 To Reviewer
- 홈 피드 데이터는 향후 주간 단위로 갱신될 예정이며, 현재는 Mock 데이터와 실시간 DB 데이터를 혼합하여 반환하도록 설계했습니다.
- `like_count` 증가 로직은 향후 찜하기 기능과 연동될 예정입니다.