### PR TITLE
Fix(server): SQS 실패 시 상태 및 에러 메시지 즉시 반영

### DIFF
--- a/backend/app/routers/analysis.py
+++ b/backend/app/routers/analysis.py
@@ -2,6 +2,7 @@
 import json
 import uuid
 import logging
+from datetime import datetime, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -66,22 +67,20 @@ async def create_analysis_job(
     await db.flush()   # id 확보
     await db.refresh(job)
 
-    # SQS 전송 — 실패해도 DB는 롤백하지 않음 (워커 재전송 가능)
+    # SQS 전송 — 실패 시 FAILED 처리 (프론트에서 폴링으로 확인 가능)
     message = json.dumps({"job_id": str(job.id), "s3_key": body.s3_key})
     msg_id = send_vocal_sqs_message(message)
     if not msg_id:
         logger.error("Vocal SQS 전송 실패 — job_id=%s", job.id)
+        job.status = "FAILED"
+        job.result_data = {
+            "error": "SQS 전송 실패: 분석 작업을 큐에 등록하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+            "failed_at": datetime.now(timezone.utc).isoformat(),
+        }
 
     await db.commit()
     await db.refresh(job)
-
-    return AnalysisJobResponse(
-        job_id=job.id,
-        status=job.status,
-        result_data=job.result_data,
-        created_at=job.created_at,
-        updated_at=job.updated_at,
-    )
+    return _to_job_response(job)
 
 
 @router.get("/jobs/{job_id}", response_model=AnalysisJobResponse)
@@ -103,14 +102,7 @@ async def get_analysis_job(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"code": "JOB_NOT_FOUND", "message": "분석 작업을 찾을 수 없습니다."},
         )
-
-    return AnalysisJobResponse(
-        job_id=job.id,
-        status=job.status,
-        result_data=job.result_data,
-        created_at=job.created_at,
-        updated_at=job.updated_at,
-    )
+    return _to_job_response(job)
 
 
 @router.get("/profile", response_model=VocalProfileResponse)
@@ -145,4 +137,18 @@ async def get_vocal_profile(
         latest_timbre_summary=profile.latest_timbre_summary,
         latest_best_genre=profile.latest_best_genre,
         updated_at=profile.updated_at,
+    )
+
+
+# ── 헬퍼 ──────────────────────────────────────────────────────
+
+def _to_job_response(job: AnalysisJob) -> AnalysisJobResponse:
+    error_msg = job.result_data.get("error") if job.result_data else None
+    return AnalysisJobResponse(
+        job_id=job.id,
+        status=job.status,
+        result_data=job.result_data,
+        error_message=error_msg,
+        created_at=job.created_at,
+        updated_at=job.updated_at,
     )

--- a/backend/app/routers/recommendations.py
+++ b/backend/app/routers/recommendations.py
@@ -1,6 +1,7 @@
 """추천 파이프라인 라우터 — Job 생성 / 상태 조회 / 2차 피드백"""
 import json
 import logging
+from datetime import datetime, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -50,6 +51,9 @@ async def create_recommendation(
     msg_id = send_sqs_message(json.dumps(payload))
     if not msg_id:
         logger.error("Recommendation SQS 전송 실패 — job_id=%s", job.id)
+        job.status = "FAILED"
+        job.error_message = "SQS 전송 실패: 추천 작업을 큐에 등록하지 못했습니다. 잠시 후 다시 시도해 주세요."
+        job.failed_at = datetime.now(timezone.utc)
 
     await db.commit()
     await db.refresh(job)
@@ -89,6 +93,7 @@ async def submit_feedback(
             },
         )
 
+    # 1. DB 먼저 — worker가 SQS 받은 후 DB에서 읽으므로 반드시 커밋 선행
     job.input_preferences = {"reranking_top3": body.reranking_top3}
     if body.selected_genre is not None:
         job.selected_genre = body.selected_genre
@@ -97,6 +102,22 @@ async def submit_feedback(
 
     await db.commit()
     await db.refresh(job)
+
+    # 2. SQS stage2 트리거 — DB 저장 완료 후 전송
+    payload = json.dumps({
+        "job_id": str(job.id),
+        "user_id": str(current_user.id),
+        "stage": "stage2",
+    })
+    msg_id = send_sqs_message(payload)
+    if not msg_id:
+        logger.error("stage2 SQS 전송 실패 — job_id=%s", job.id)
+        job.status = "FAILED"
+        job.error_message = "SQS 전송 실패: 2차 추천 작업을 큐에 등록하지 못했습니다. 잠시 후 다시 시도해 주세요."
+        job.failed_at = datetime.now(timezone.utc)
+        await db.commit()
+        await db.refresh(job)
+
     return _to_response(job)
 
 
@@ -142,6 +163,12 @@ def _to_response(job: Recommendation) -> RecommendationStatusResponse:
         status=job.status,
         first_recommended_songs=job.first_recommended_songs,
         recommended_songs=job.recommended_songs,
+        error_message=job.error_message,
+        failed_at=job.failed_at,
+        stage1_started_at=job.stage1_started_at,
+        stage1_completed_at=job.stage1_completed_at,
+        stage2_started_at=job.stage2_started_at,
+        stage2_completed_at=job.stage2_completed_at,
         created_at=job.created_at,
         updated_at=job.updated_at,
     )

--- a/backend/app/schemas/analysis.py
+++ b/backend/app/schemas/analysis.py
@@ -19,6 +19,8 @@ class AnalysisJobResponse(BaseModel):
     job_id: UUID
     status: str
     result_data: Optional[Dict[str, Any]] = None
+    # FAILED 시 에러 원인 (result_data["error"] 에서 추출)
+    error_message: Optional[str] = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/recommendation.py
+++ b/backend/app/schemas/recommendation.py
@@ -20,6 +20,17 @@ class RecommendationStatusResponse(BaseModel):
     status: Optional[str] = None
     first_recommended_songs: Optional[List[Dict[str, Any]]] = None
     recommended_songs: Optional[Dict[str, Any]] = None
+
+    # 에러 정보 (status=FAILED 일 때)
+    error_message: Optional[str] = None
+    failed_at: Optional[datetime] = None
+
+    # 단계별 진행 타임스탬프
+    stage1_started_at: Optional[datetime] = None
+    stage1_completed_at: Optional[datetime] = None
+    stage2_started_at: Optional[datetime] = None
+    stage2_completed_at: Optional[datetime] = None
+
     created_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
## 📌 Related Issue
- Closes #182

## 📤 Tasks
- **파이프라인 SQS 에러 상태 노출 개선**
- **실패 처리 로직 강화**
  - SQS 전송 실패 시 `job status=FAILED` + `error_message` 즉시 기록 (기존: 로그만 남김)
- **응답 스키마 확장**
  - `RecommendationStatusResponse`: `error_message`, `failed_at`, stage별 타임스탬프 추가
  - `AnalysisJobResponse`: `error_message` 추가
- **라우터 로직 수정**
  - 분석 및 추천 라우터에서 예외 발생 시 상태값 갱신 로직 반영

<br/>

## 📸 Screenshot
<br/>

## 💌 To Reviewer
- SQS 메시지 큐 전송 실패 상황에서 유저가 무한 대기에 빠지지 않도록 상태 처리를 강화했습니다.
- 스키마에 추가된 타임스탬프를 통해 향후 성능 병목 구간 분석도 가능할 것으로 보입니다.