### PR TITLE
Feat(server): 에러 응답 형식 통일 및 HTTP 상태 코드 정정

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -41,7 +41,7 @@ async def social_login(
     if provider not in ("kakao", "naver"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"지원하지 않는 provider: {provider}",
+            detail={"code": "UNSUPPORTED_PROVIDER", "message": f"지원하지 않는 로그인 provider입니다: {provider}. kakao 또는 naver만 가능합니다."},
         )
 
     try:
@@ -69,7 +69,7 @@ async def social_login(
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
+            detail={"code": "LOGIN_FAILED", "message": str(e)},
         )
 
 
@@ -94,7 +94,7 @@ async def refresh(
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=str(e),
+            detail={"code": "INVALID_TOKEN", "message": str(e)},
         )
 
 

--- a/backend/app/routers/busking.py
+++ b/backend/app/routers/busking.py
@@ -155,7 +155,10 @@ async def get_thumbnail_presigned_url(
     key = f"busking/thumbnails/{current_user.id}/{uuid_lib.uuid4()}.jpg"
     upload_url = generate_presigned_url(key, content_type="image/jpeg")
     if not upload_url:
-        raise HTTPException(status_code=500, detail="Presigned URL 생성 실패")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={"code": "S3_URL_FAILED", "message": "썸네일 업로드 URL 생성에 실패했습니다. 잠시 후 다시 시도해 주세요."},
+        )
     s3_url = f"https://{settings.S3_BUCKET_NAME}.s3.{settings.AWS_REGION}.amazonaws.com/{key}"
     return ThumbnailPresignedResponse(upload_url=upload_url, s3_url=s3_url, key=key)
 
@@ -256,7 +259,10 @@ async def start_room(
     _require_host(room, current_user)
 
     if room.status != "PREPARING":
-        raise HTTPException(status_code=400, detail=f"PREPARING 상태가 아닙니다 (현재: {room.status})")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "INVALID_STATUS", "message": f"PREPARING 상태인 방만 라이브를 시작할 수 있습니다. (현재: {room.status})"},
+        )
 
     room.status = "LIVE"
     room.started_at = datetime.now(timezone.utc)
@@ -284,7 +290,10 @@ async def end_room(
     _require_host(room, current_user)
 
     if room.status != "LIVE":
-        raise HTTPException(status_code=400, detail=f"LIVE 상태가 아닙니다 (현재: {room.status})")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "INVALID_STATUS", "message": f"LIVE 상태인 방만 종료할 수 있습니다. (현재: {room.status})"},
+        )
 
     now = datetime.now(timezone.utc)
     room.status = "ENDED"
@@ -331,7 +340,10 @@ async def join_room(
     """뷰어 입장용 LiveKit 토큰 발급. LIVE 상태인 방만 허용."""
     room = await _get_room_or_404(db, room_id)
     if room.status != "LIVE":
-        raise HTTPException(status_code=400, detail="라이브 중인 방에만 입장할 수 있습니다.")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "ROOM_NOT_LIVE", "message": "라이브 중인 방에만 입장할 수 있습니다."},
+        )
 
     viewer_token = create_viewer_token(room_id, str(current_user.id))
     return LiveKitJoinResponse(
@@ -354,11 +366,17 @@ async def advance_setlist(
     _require_host(room, current_user)
 
     if room.status != "LIVE":
-        raise HTTPException(status_code=400, detail="라이브 중에만 곡을 변경할 수 있습니다.")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "ROOM_NOT_LIVE", "message": "라이브 중에만 곡을 변경할 수 있습니다."},
+        )
 
     setlist = await _get_setlist(db, room_id)
     if room.current_song_index >= len(setlist) - 1:
-        raise HTTPException(status_code=400, detail="이미 마지막 곡입니다.")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "ALREADY_LAST_SONG", "message": "이미 마지막 곡입니다."},
+        )
 
     room.current_song_index += 1
     await db.flush()
@@ -378,13 +396,19 @@ async def get_result(room_id: UUID, db: AsyncSession = Depends(get_db)):
     """라이브 종료 후 결과 조회."""
     room = await _get_room_or_404(db, room_id)
     if room.status != "ENDED":
-        raise HTTPException(status_code=400, detail="종료된 방만 결과를 조회할 수 있습니다.")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "ROOM_NOT_ENDED", "message": f"종료된 방만 결과를 조회할 수 있습니다. (현재: {room.status})"},
+        )
 
     result_row = (await db.execute(
         select(BuskingResult).where(BuskingResult.room_id == room_id)
     )).scalar_one_or_none()
     if not result_row:
-        raise HTTPException(status_code=404, detail="결과 데이터가 없습니다.")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "RESULT_NOT_FOUND", "message": "결과 데이터가 없습니다."},
+        )
 
     setlist = await _get_setlist(db, room_id)
     return BuskingResultResponse(
@@ -556,7 +580,10 @@ async def _get_room_or_404(db: AsyncSession, room_id) -> BuskingRoom:
     result = await db.execute(select(BuskingRoom).where(BuskingRoom.id == room_id))
     room = result.scalar_one_or_none()
     if not room:
-        raise HTTPException(status_code=404, detail="방을 찾을 수 없습니다.")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "ROOM_NOT_FOUND", "message": "버스킹 방을 찾을 수 없습니다."},
+        )
     return room
 
 
@@ -571,7 +598,10 @@ async def _get_setlist(db: AsyncSession, room_id) -> list[BuskingSetlistItem]:
 
 def _require_host(room: BuskingRoom, user: User):
     if str(room.host_id) != str(user.id):
-        raise HTTPException(status_code=403, detail="호스트만 수행할 수 있는 작업입니다.")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "FORBIDDEN", "message": "호스트만 수행할 수 있는 작업입니다."},
+        )
 
 
 def _build_room_response(room: BuskingRoom, viewer_count: int) -> BuskingRoomResponse:

--- a/backend/app/routers/songs.py
+++ b/backend/app/routers/songs.py
@@ -1,22 +1,37 @@
-from fastapi import APIRouter, Depends
+import logging
+from fastapi import APIRouter, HTTPException, status
 from app.services.spotify import SpotifyService
-from app.config import settings # .env에 저장한 키 가져오기
+from app.config import settings
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/music", tags=["music"])
 
 spotify = SpotifyService(settings.SPOTIFY_CLIENT_ID, settings.SPOTIFY_CLIENT_SECRET)
 
+
 @router.get("/search")
 async def search_music(q: str):
-    results = await spotify.search_tracks(q)
+    if not q or not q.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "EMPTY_QUERY", "message": "검색어를 입력해 주세요."},
+        )
+    try:
+        results = await spotify.search_tracks(q)
+    except Exception as e:
+        logger.error("Spotify 검색 실패: q=%s error=%s", q, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={"code": "SPOTIFY_ERROR", "message": "음악 검색에 실패했습니다. 잠시 후 다시 시도해 주세요."},
+        )
 
-    # 필요한 정보(제목, 가수, 앨범커버, URI)만 추려서 프론트에 전달
     tracks = []
     for item in results.get("tracks", {}).get("items", []):
         images = item["album"].get("images", [])
+        artists = item.get("artists", [])
         tracks.append({
             "name": item["name"],
-            "artist": item["artists"][0]["name"],
+            "artist": artists[0]["name"] if artists else "",
             "album_image": images[0]["url"] if images else None,
             "uri": item["uri"],
         })

--- a/backend/app/routers/user.py
+++ b/backend/app/routers/user.py
@@ -308,7 +308,7 @@ async def update_profile(
     if not update_data:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="수정할 항목이 없습니다.",
+            detail={"code": "NOTHING_TO_UPDATE", "message": "수정할 항목이 없습니다."},
         )
     service = UserService(db)
     updated = await service.update_profile(
@@ -336,7 +336,7 @@ async def update_settings(
     if not update_data:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="수정할 항목이 없습니다.",
+            detail={"code": "NOTHING_TO_UPDATE", "message": "수정할 항목이 없습니다."},
         )
     service = UserService(db)
     return await service.update_settings(


### PR DESCRIPTION
## 📌 Related Issue
- Closes #184

## 📤 Tasks
- **전체 API 에러 응답 형식 통일**
- **응답 포맷 규격화**
  - 기존 plain string `detail` → `{"code": "SNAKE_CASE", "message": "한국어"}` 형식으로 일괄 수정
- **HTTP 상태 코드 및 예외 처리 정정**
  - 버스킹 상태 충돌 에러: HTTP 400 → 409로 정정
  - 외부 API(Spotify) 실패 시 502 에러 처리 로직 추가
- **공통 예외 처리 적용**
  - `auth`, `busking`, `user`, `songs` 라우터 전반에 적용

<br/>

## 📸 Screenshot
<br/>

## 💌 To Reviewer
- 프론트엔드와의 원활한 통신을 위해 에러 응답 규격을 하나로 맞췄습니다. 
- 상태 코드 정정을 통해 의미론적으로 더 정확한 API 설계를 지향했습니다.