### PR TITLE
Fix(server): live 기능 song_id 관련 nullable로 변경

### DIFF
--- a/backend/app/routers/busking.py
+++ b/backend/app/routers/busking.py
@@ -184,7 +184,7 @@ async def create_room(
     items = [
         BuskingSetlistItem(
             room_id=room.id,
-            song_id=item.song_id,
+            song_id=item.song_id or None,   # Spotify URI 또는 내부 UUID — 없으면 NULL
             title=item.title,
             artist=item.artist,
             album_art_url=item.album_art_url,

--- a/backend/scripts/migrate_busking.py
+++ b/backend/scripts/migrate_busking.py
@@ -29,6 +29,11 @@ ALTER_BUSKING_ROOMS = [
     "ALTER TABLE busking_rooms ADD COLUMN IF NOT EXISTS total_unique_viewers INTEGER DEFAULT 0",
 ]
 
+# ── busking_setlist_items 신규 컬럼 (테이블이 이미 존재할 때 song_id 누락 방지) ──
+ALTER_SETLIST_ITEMS = [
+    "ALTER TABLE busking_setlist_items ADD COLUMN IF NOT EXISTS song_id TEXT",
+]
+
 # ── 신규 테이블 ────────────────────────────────────────────────
 CREATE_SETLIST = """
 CREATE TABLE IF NOT EXISTS busking_setlist_items (
@@ -85,6 +90,11 @@ async def run():
         for stmt in ALTER_BUSKING_ROOMS:
             await conn.execute(text(stmt))
             logger.info("  OK: %s", stmt[:60])
+
+        logger.info("busking_setlist_items 컬럼 보완 중...")
+        for stmt in ALTER_SETLIST_ITEMS:
+            await conn.execute(text(stmt))
+            logger.info("  OK: %s", stmt[:80])
 
         logger.info("신규 테이블 생성 중...")
         for name, ddl in [


### PR DESCRIPTION
## 📌 Related Issue
- Closes #193

## 📤 Tasks
- **DB 마이그레이션 스크립트 보완**
  - `backend/scripts/migrate_busking.py` 수정
  - `ALTER TABLE busking_setlist_items ADD COLUMN IF NOT EXISTS song_id TEXT` 명령어 추가
- **버스킹 방 생성 API 예외 처리 강화**
  - `backend/app/routers/busking.py` 수정
  - 셋리스트 아이템 인서트 시 `song_id = item.song_id or None` 로직 적용
- **데이터 무결성 확보**
  - 빈 값이 들어올 경우 DB 제약 조건에 걸리지 않도록 명시적 NULL 처리
<br/>

## 📸 Screenshot
<br/>

## 💌 To Reviewer
- 기존 `CREATE TABLE IF NOT EXISTS` 패턴은 테이블이 이미 존재할 경우 컬럼 변경사항을 반영하지 못하는 한계가 있었습니다. 
- 이를 해결하기 위해 명시적인 `ALTER TABLE` 구문을 추가하여 마이그레이션 안정성을 확보했습니다.
- - Spotify 검색 결과 중 간혹 ID가 없는 데이터가 포함될 경우 인서트가 실패하던 버그를 잡았습니다.
- 이 수정으로 인해 셋리스트 구성 시 안정적인 방 생성이 가능해졌습니다.