### PR TITLE
Fix(server): 최종 추천 곡 응답에 장르 정보 추가

### DIFF
--- a/backend/app/routers/recommendations.py
+++ b/backend/app/routers/recommendations.py
@@ -210,9 +210,9 @@ async def _to_response_with_song_info(job: Recommendation, db: AsyncSession) -> 
             except ValueError:
                 pass
         if uuids:
-            result = await db.execute(select(Song.id, Song.key, Song.bpm).where(Song.id.in_(uuids)))
+            result = await db.execute(select(Song.id, Song.key, Song.bpm, Song.genre).where(Song.id.in_(uuids)))
             for row in result.all():
-                song_map[str(row.id)] = {"key": row.key, "bpm": row.bpm}
+                song_map[str(row.id)] = {"key": row.key, "bpm": row.bpm, "genre": row.genre}
 
     # 3. enrichment 헬퍼
     def enrich(item: dict) -> dict:
@@ -221,7 +221,10 @@ async def _to_response_with_song_info(job: Recommendation, db: AsyncSession) -> 
             return item
         extra = dict(song_map[sid])
         if extra.get("key"):
-            extra["key"] = extra["key"].title()  # "D# major" → "D# Major", "C major" → "C Major"
+            extra["key"] = extra["key"].title()
+        if extra.get("genre"):
+            genres = [g.strip() for g in extra["genre"].split(",") if g.strip() != "전체"]
+            extra["genre"] = genres[0] if genres else None
         return {**item, **extra}
 
     enriched_first = [enrich(i) for i in first]


### PR DESCRIPTION
## 📌 Related Issue
- Closes #200

## 📤 Tasks
- **추천 곡 응답 내 장르(genre) 필드 추가 및 데이터 정제**
- **데이터 필드 확장**
  - `songs` 테이블 조회 로직에 `genre` 컬럼을 추가하여 추천 결과와 머지
- **장르 데이터 정화 로직 구현**
  - "전체,발라드" 등 복수 장르로 구성된 문자열에서 "전체" 키워드 제거
  - 정제된 결과 중 첫 번째 유효 장르 값만 반환하도록 처리
  - 장르가 "전체" 단독이거나 빈 값인 경우 `null`을 반환하여 UI 노출 방지
- **파일 수정**
  - `backend/app/routers/recommendations.py` 내 Enrichment 로직 수정

<br/>

## 📸 Screenshot
<br/>

## 💌 To Reviewer
- 추천 결과에서 장르 텍스트가 지저분하게 나오는 현상을 방지하기 위해 백엔드 단에서 전처리를 수행했습니다.
- `.split(',')`으로 나누고 필터링하는 과정에서 발생할 수 있는 인덱스 오류를 방지하기 위해 안전한 폴백(null) 처리를 적용했으니 확인 부탁드립니다.