### PR TITLE
Feat(client): 버스킹 캐러셀 UI 구현

### DIFF
--- a/frontend/apps/client/src/app/(main)/live/page.tsx
+++ b/frontend/apps/client/src/app/(main)/live/page.tsx
@@ -24,7 +24,7 @@ const BuskingListPage = () => {
 
   return (
     <>
-      <main className='flex flex-col gap-10'>
+      <main className='flex flex-col'>
         <PageBanner
           category='온라인 버스킹'
           title='온라인 버스킹으로 노래를 들려주고, 내 목소리와 곡의 어울림을 확인해보세요!'
@@ -40,8 +40,16 @@ const BuskingListPage = () => {
           </div>
 
           <div className='flex flex-col gap-6'>
-            <BuskingSection title='NOW ON AIR! 최근 업로드된 버스킹' items={rooms} onItemClick={handleRoomClick} />
-            <BuskingSection title='지금 인기 있는 버스킹' items={rooms} onItemClick={handleRoomClick} />
+            <BuskingSection
+              title='NOW ON AIR! 최근 업로드된 버스킹'
+              items={rooms}
+              onItemClick={handleRoomClick}
+            />
+            <BuskingSection
+              title='지금 인기 있는 버스킹'
+              items={rooms}
+              onItemClick={handleRoomClick}
+            />
           </div>
         </div>
       </main>

--- a/frontend/apps/client/src/app/(main)/live/page.tsx
+++ b/frontend/apps/client/src/app/(main)/live/page.tsx
@@ -4,23 +4,16 @@ import { BuskingCarousel, BuskingSection } from '@/widgets/busking-list/ui';
 import { Button } from '@singchronize/ui';
 import { PageBanner } from '@/shared/components';
 import { useModal } from '@/shared/hooks';
-import { useNavigate } from '@/shared/lib/navigation';
 import { LiveStartModal } from '@/features/busking/ui';
 import { RecordUploadModal } from '@/features/record-upload';
 
 import { useBuskingRooms } from '@/entities/busking';
-import type { BuskingUiType } from '@/entities/busking';
 
 const BuskingListPage = () => {
-  const { go, dynamic } = useNavigate();
   const liveStartModal = useModal();
   const recordUploadModal = useModal();
 
   const { data: rooms = [] } = useBuskingRooms();
-
-  const handleRoomClick = (item: BuskingUiType) => {
-    go(dynamic.liveRoom(item.id, item.status));
-  };
 
   return (
     <>
@@ -40,16 +33,8 @@ const BuskingListPage = () => {
           </div>
 
           <div className='flex flex-col gap-6'>
-            <BuskingSection
-              title='NOW ON AIR! 최근 업로드된 버스킹'
-              items={rooms}
-              onItemClick={handleRoomClick}
-            />
-            <BuskingSection
-              title='지금 인기 있는 버스킹'
-              items={rooms}
-              onItemClick={handleRoomClick}
-            />
+            <BuskingSection title='NOW ON AIR! 최근 업로드된 버스킹' items={rooms} />
+            <BuskingSection title='지금 인기 있는 버스킹' items={rooms} />
           </div>
         </div>
       </main>

--- a/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
+++ b/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
@@ -288,7 +288,6 @@ const BuskingViewerPage = () => {
               listClassName='px-9 gap-2'
               cardVariant='sm'
               items={rooms}
-              onItemClick={(item) => go(dynamic.liveRoom(item.id, item.status))}
             />
           </div>
         )}

--- a/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
+++ b/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
@@ -20,6 +20,7 @@ import {
   SetlistPanel,
   VotePanel,
   LiveChat,
+  SetlistCarousel,
 } from '@/features/busking/ui';
 import { useBuskingSocket } from '@/features/busking/hooks/useBuskingSocket';
 import { BuskingBadge } from '@/entities/busking/ui';
@@ -61,7 +62,7 @@ const BuskingViewerPage = () => {
   const { data: me } = useMe();
   const { data: room } = useBuskingRoom(roomId);
   const { data: rooms = [] } = useBuskingRooms();
-  const { mutate: endRoom } = useEndBuskingRoom();
+  const { mutate: endRoom, isPending: isEndingRoom } = useEndBuskingRoom();
   const { mutateAsync: joinRoom } = useJoinBuskingRoom();
   const { mutate: advanceSetlist, isPending: isAdvancing } = useAdvanceSetlist();
 
@@ -172,6 +173,7 @@ const BuskingViewerPage = () => {
 
   // 스트리머: 모달에서 확인 → 소켓 종료 후 결과 페이지
   const handleConfirmEndLive = () => {
+    if (isEndingRoom) return;
     endLive();
     endRoom(roomId, {
       onSuccess: () => go(dynamic.liveRoomEnd(roomId, 'live')),
@@ -219,7 +221,12 @@ const BuskingViewerPage = () => {
           <BuskingBadge isRecord={isRecord} duration={liveDuration} className='ml-4' />
 
           {isStreamer && (
-            <Button variant={'accent'} className='ml-auto' onClick={handleEndLive}>
+            <Button
+              variant={'accent'}
+              className='ml-auto'
+              onClick={handleEndLive}
+              disabled={isEndingRoom}
+            >
               라이브 버스킹 종료하기
             </Button>
           )}
@@ -267,15 +274,12 @@ const BuskingViewerPage = () => {
 
         {/* 다른 버스킹 */}
         {isStreamer ? (
-          <div className='h-62 flex items-center justify-center'>
-            <Button
-              variant='normal'
-              onClick={handleAdvanceSetlist}
-              disabled={isAdvancing || isLastSong}
-            >
-              다음 곡으로
-            </Button>
-          </div>
+          <SetlistCarousel
+            items={room?.setlist ?? []}
+            isAdvancing={isAdvancing}
+            isLastSong={isLastSong}
+            onNext={handleAdvanceSetlist}
+          />
         ) : (
           <div className='pt-5 pb-7 bg-gray-950'>
             <BuskingSection
@@ -300,10 +304,13 @@ const BuskingViewerPage = () => {
         <HostLiveEndModal
           onClose={endModal.closeModal}
           onConfirm={handleConfirmEndLive}
+          isPending={isEndingRoom}
         />
       )}
 
-      {viewerEndModal.open && <ViewerLiveEndModal onConfirm={handleConfirmViewerEnd} />}
+      {viewerEndModal.open && (
+        <ViewerLiveEndModal onConfirm={handleConfirmViewerEnd} isPending={isEndingRoom} />
+      )}
     </div>
   );
 };

--- a/frontend/apps/client/src/entities/busking/ui/BuskingCard.tsx
+++ b/frontend/apps/client/src/entities/busking/ui/BuskingCard.tsx
@@ -59,6 +59,12 @@ const listenerTypoMap: Record<BuskingCardVariant, string> = {
   lg: 'typo-16r text-gray-300',
 };
 
+const badgePositionMap: Record<BuskingCardVariant, string> = {
+  sm: 'left-2 top-1.75',
+  md: 'left-3 top-2.5',
+  lg: 'left-4.75 top-2.75',
+};
+
 const bottomAreaClassMap: Record<BuskingCardVariant, string> = {
   sm: 'h-12 px-2 bg-gray-800',
   md: 'h-17 px-3 bg-gray-800',
@@ -83,7 +89,7 @@ const BuskingCard = ({ variant = 'md', item, onClick }: BuskingCardProps) => {
       </div>
 
       {/* 상단 배지 */}
-      <div className='absolute left-2.5 top-2.5 z-10'>
+      <div className={cn('absolute z-10', badgePositionMap[variant])}>
         <span
           className={cn(
             'inline-flex items-center',

--- a/frontend/apps/client/src/entities/busking/ui/BuskingCard.tsx
+++ b/frontend/apps/client/src/entities/busking/ui/BuskingCard.tsx
@@ -14,9 +14,9 @@ interface BuskingCardProps {
 }
 
 const variantClassMap: Record<BuskingCardVariant, string> = {
-  sm: 'w-[192px] h-[153px]',
-  md: 'w-[350px] h-[222px]',
-  lg: 'w-[530px] h-[300px]',
+  sm: 'w-[192px] h-[153px] rounded-10',
+  md: 'w-[350px] h-[222px] rounded-[15px]',
+  lg: 'w-[530px] h-[300px] rounded-20',
 };
 
 const badgeVariantClassMap: Record<BuskingCardVariant, string> = {
@@ -79,7 +79,7 @@ const BuskingCard = ({ variant = 'md', item, onClick }: BuskingCardProps) => {
       type='button'
       onClick={onClick}
       className={cn(
-        'relative overflow-hidden rounded-10 bg-gray-800 text-left shrink-0',
+        'relative overflow-hidden bg-gray-800 text-left shrink-0',
         variantClassMap[variant],
       )}
     >

--- a/frontend/apps/client/src/features/busking/ui/LiveEndModal.tsx
+++ b/frontend/apps/client/src/features/busking/ui/LiveEndModal.tsx
@@ -8,20 +8,22 @@ type HostLiveEndModalProps = {
   onClose: () => void;
   onConfirm: () => void;
   thumbnail?: string;
+  isPending?: boolean;
 };
 
 export const HostLiveEndModal = ({
   onClose,
   onConfirm,
   thumbnail,
+  isPending = false,
 }: HostLiveEndModalProps) => {
   return (
     <BaseModal
-      onClose={onClose}
+      onClose={isPending ? () => {} : onClose}
       className={cn(
         'relative p-10 flex flex-col justify-center items-center w-full max-w-198 max-h-178 h-[70vh] rounded-20',
         'bg-bg bg-[radial-gradient(50%_50%_at_50%_50%,rgba(240,48,58,0.17)_0%,rgba(22,22,22,0.17)_100%)]',
-        'bg-size-[130%_280%] bg-position-[50%_0%]',
+        'bg-size-[80%_280%] bg-position-[50%_0%]',
       )}
     >
       <div className='flex flex-col gap-9 w-103'>
@@ -46,7 +48,12 @@ export const HostLiveEndModal = ({
         </ul>
       </div>
 
-      <Button variant={'accent'} className='mt-[6vh]' onClick={onConfirm}>
+      <Button
+        variant={'accent'}
+        className='mt-[6vh]'
+        onClick={onConfirm}
+        disabled={isPending}
+      >
         라이브 버스킹 종료 후 리포트 받기
       </Button>
     </BaseModal>
@@ -55,12 +62,16 @@ export const HostLiveEndModal = ({
 
 type ViewerLiveEndModalProps = {
   onConfirm: () => void;
+  isPending?: boolean;
 };
 
-export const ViewerLiveEndModal = ({ onConfirm }: ViewerLiveEndModalProps) => {
+export const ViewerLiveEndModal = ({
+  onConfirm,
+  isPending = false,
+}: ViewerLiveEndModalProps) => {
   return (
     <BaseModal
-      onClose={onConfirm}
+      onClose={isPending ? () => {} : onConfirm}
       className={cn(
         'relative p-10 flex flex-col justify-center items-center w-full max-w-198 max-h-178 h-[70vh] rounded-20',
         'bg-bg bg-[radial-gradient(50%_50%_at_50%_50%,rgba(200,255,0,0.15)_0%,rgba(22,22,22,0.17)_100%)]',
@@ -72,7 +83,12 @@ export const ViewerLiveEndModal = ({ onConfirm }: ViewerLiveEndModalProps) => {
         <p className='typo-16r text-gray-200 text-center'>버스킹이 종료되었습니다.</p>
       </div>
 
-      <Button variant='accent' className='mt-[6vh]' onClick={onConfirm}>
+      <Button
+        variant='accent'
+        className='mt-[6vh]'
+        onClick={onConfirm}
+        disabled={isPending}
+      >
         버스킹 목록으로 돌아가기
       </Button>
     </BaseModal>

--- a/frontend/apps/client/src/features/busking/ui/SetlistCarousel.tsx
+++ b/frontend/apps/client/src/features/busking/ui/SetlistCarousel.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { IcArrowRight } from '@/shared/assets/icons';
+import { AppImage } from '@/shared/components';
+import { cn } from '@/shared/lib/cn';
+import type { SetlistType } from '@/entities/busking/model/types';
+
+type SetlistCarouselProps = {
+  items: SetlistType[];
+  isAdvancing: boolean;
+  isLastSong: boolean;
+  onNext: () => void;
+};
+
+type AlbumCardProps = {
+  item: SetlistType;
+};
+
+const CARD_WIDTH = 154;
+const CARD_HEIGHT = 154;
+const CARD_GAP_STEP = 112;
+const ARROW_OFFSET = 52;
+
+const SetlistCarousel = ({
+  items,
+  isAdvancing,
+  isLastSong,
+  onNext,
+}: SetlistCarouselProps) => {
+  const currentItemIndex = items.findIndex((item) => item.isCurrent);
+  const syncedIndex = currentItemIndex >= 0 ? currentItemIndex : 0;
+
+  const [activeIndex, setActiveIndex] = useState(syncedIndex);
+
+  useEffect(() => {
+    setActiveIndex(syncedIndex);
+  }, [syncedIndex]);
+
+  if (!items.length) return null;
+
+  const currentSong = items[activeIndex];
+
+  const isLastIndex = activeIndex === items.length - 1;
+
+  const disabledNext = isAdvancing || isLastSong || isLastIndex;
+
+  const trackWidth = (items.length - 1) * CARD_GAP_STEP + CARD_WIDTH;
+  const translateX = activeIndex * CARD_GAP_STEP + CARD_WIDTH / 2;
+
+  const handleNext = () => {
+    if (disabledNext) return;
+
+    onNext();
+    setActiveIndex((prevIndex) => Math.min(items.length - 1, prevIndex + 1));
+  };
+
+  return (
+    <section className='relative flex h-62 flex-col items-center justify-center overflow-hidden'>
+      <div className='relative w-full overflow-hidden' style={{ height: CARD_HEIGHT }}>
+        <div
+          className='absolute top-0 transition-transform duration-300 ease-in-out'
+          style={{
+            left: '50%',
+            width: trackWidth,
+            height: CARD_HEIGHT,
+            transform: `translateX(-${translateX}px)`,
+          }}
+        >
+          {items.map((item, index) => {
+            const distanceFromActive = Math.abs(index - activeIndex);
+            const isActive = index === activeIndex;
+            const isNearActive = distanceFromActive === 1;
+
+            return (
+              <div
+                key={item.id}
+                className={cn(
+                  'absolute transition-all duration-300 ease-in-out',
+                  isActive && 'z-10 scale-100 opacity-100',
+                  isNearActive && 'z-0 scale-90 opacity-50',
+                  !isActive &&
+                    !isNearActive &&
+                    'z-0 scale-90 opacity-0 pointer-events-none',
+                )}
+                style={{
+                  left: index * CARD_GAP_STEP,
+                  top: 0,
+                  width: CARD_WIDTH,
+                  height: CARD_HEIGHT,
+                }}
+              >
+                <AlbumCard item={item} />
+              </div>
+            );
+          })}
+        </div>
+
+        {!isLastIndex && (
+          <button
+            type='button'
+            onClick={handleNext}
+            aria-label='다음 곡으로'
+            disabled={disabledNext}
+            className={cn(
+              'absolute top-1/2 z-20 flex size-12 -translate-x-1/2 -translate-y-1/2',
+              'items-center justify-center',
+              'disabled:cursor-not-allowed disabled:opacity-35',
+            )}
+            style={{ left: `calc(50% + ${CARD_WIDTH / 2 + ARROW_OFFSET}px)` }}
+          >
+            {isAdvancing ? (
+              <span className='typo-18m'>...</span>
+            ) : (
+              <IcArrowRight className='text-white' />
+            )}
+          </button>
+        )}
+      </div>
+
+      <div className='relative mt-2 text-center'>
+        <p className='typo-18sb text-white'>
+          {currentSong?.title ?? '현재 재생 중인 곡'}
+        </p>
+        <p className='typo-14r text-gray-300'>{currentSong?.artist ?? ''}</p>
+      </div>
+    </section>
+  );
+};
+
+const AlbumCard = ({ item }: AlbumCardProps) => {
+  return (
+    <div className='relative size-full shrink-0 overflow-hidden rounded-10 bg-gray-800'>
+      {item.thumbnail ? (
+        <AppImage src={item.thumbnail} alt={item.title} fill className='object-cover' />
+      ) : (
+        <div className='flex size-full items-center justify-center px-4 text-center'>
+          <span className='typo-14m text-gray-300'>{item.title}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SetlistCarousel;

--- a/frontend/apps/client/src/features/busking/ui/index.ts
+++ b/frontend/apps/client/src/features/busking/ui/index.ts
@@ -2,5 +2,6 @@ export { default as BuskingVideoRoom } from './BuskingVideoRoom';
 export { default as LiveChat } from './LiveChat';
 export { HostLiveEndModal, ViewerLiveEndModal } from './LiveEndModal';
 export { default as LiveStartModal } from './LiveStartModal';
+export { default as SetlistCarousel } from './SetlistCarousel';
 export { default as SetlistPanel } from './SetlistPanel';
 export { default as VotePanel } from './VotePanel';

--- a/frontend/apps/client/src/shared/assets/icons/ic_arrow_right.svg
+++ b/frontend/apps/client/src/shared/assets/icons/ic_arrow_right.svg
@@ -1,3 +1,3 @@
 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 24L20 16L12 8" stroke="#7B7B7B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 24L20 16L12 8" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/frontend/apps/client/src/shared/components/ReportCard.tsx
+++ b/frontend/apps/client/src/shared/components/ReportCard.tsx
@@ -23,7 +23,7 @@ const ReportCard = ({
     <section
       className={cn(
         'p-6 flex flex-col h-full md:h-90 bg-bg border border-gray-600 rounded-20',
-        className
+        className,
       )}
       onClick={onClick}
     >
@@ -34,7 +34,7 @@ const ReportCard = ({
         </div>
 
         {!hideArrow ? (
-          <button type='button' className='shrink-0'>
+          <button type='button' className='shrink-0 text-gray-500 '>
             <IcArrowRight />
           </button>
         ) : null}

--- a/frontend/apps/client/src/widgets/busking-list/ui/BuskingCarousel.tsx
+++ b/frontend/apps/client/src/widgets/busking-list/ui/BuskingCarousel.tsx
@@ -13,7 +13,7 @@ const STEP = 280;
 
 const BuskingCarousel = ({ items }: { items: BuskingUiType[] }) => {
   const [index, setIndex] = useState(0);
-  const { dynamic } = useNavigate();
+  const { go, dynamic } = useNavigate();
 
   if (!items.length) return null;
 
@@ -55,7 +55,7 @@ const BuskingCarousel = ({ items }: { items: BuskingUiType[] }) => {
                 if (i !== index) {
                   setIndex(i);
                 } else {
-                  window.location.href = dynamic.liveRoom(item.id, item.status);
+                  go(dynamic.liveRoom(item.id, item.status));
                 }
               }}
             />

--- a/frontend/apps/client/src/widgets/busking-list/ui/BuskingCarousel.tsx
+++ b/frontend/apps/client/src/widgets/busking-list/ui/BuskingCarousel.tsx
@@ -72,7 +72,7 @@ const BuskingCarousel = ({ items }: { items: BuskingUiType[] }) => {
           className='absolute top-1/2 -translate-x-1/2 -translate-y-1/2 z-20 size-12 rounded-full bg-white flex items-center justify-center shadow-lg'
           style={{ left: `calc(50% - ${CARD_W / 2 + 48}px)` }}
         >
-          <IcArrowRight className='rotate-180' />
+          <IcArrowRight className='rotate-180 text-black' />
         </button>
       )}
 
@@ -85,7 +85,7 @@ const BuskingCarousel = ({ items }: { items: BuskingUiType[] }) => {
           className='absolute top-1/2 -translate-x-1/2 -translate-y-1/2 z-20 size-12 rounded-full bg-white flex items-center justify-center shadow-lg'
           style={{ left: `calc(50% + ${CARD_W / 2 + 48}px)` }}
         >
-          <IcArrowRight />
+          <IcArrowRight className='text-black' />
         </button>
       )}
     </div>

--- a/frontend/apps/client/src/widgets/busking-list/ui/BuskingCarousel.tsx
+++ b/frontend/apps/client/src/widgets/busking-list/ui/BuskingCarousel.tsx
@@ -1,9 +1,95 @@
 'use client';
 
+import { useState } from 'react';
+import { cn } from '@/shared/lib/cn';
+import { IcArrowRight } from '@/shared/assets/icons';
+import { useNavigate } from '@/shared/lib/navigation';
+import { BuskingCard } from '@/entities/busking/ui';
 import type { BuskingUiType } from '@/entities/busking/model/types';
 
+const CARD_W = 530;
+const CARD_H = 300;
+const STEP = 280;
+
 const BuskingCarousel = ({ items }: { items: BuskingUiType[] }) => {
-  return <div></div>;
+  const [index, setIndex] = useState(0);
+  const { dynamic } = useNavigate();
+
+  if (!items.length) return null;
+
+  const prev = () => setIndex((i) => Math.max(0, i - 1));
+  const next = () => setIndex((i) => Math.min(items.length - 1, i + 1));
+
+  const trackW = (items.length - 1) * STEP + CARD_W;
+  const translateX = index * STEP + CARD_W / 2;
+
+  return (
+    <div className='relative w-full overflow-hidden' style={{ height: CARD_H }}>
+      {/* 트랙 */}
+      <div
+        className='absolute top-0 transition-transform duration-300 ease-in-out'
+        style={{
+          left: '50%',
+          transform: `translateX(-${translateX}px)`,
+          width: trackW,
+          height: CARD_H,
+        }}
+      >
+        {items.map((item, i) => (
+          <div
+            key={item.id}
+            className={cn(
+              'absolute transition-all duration-300',
+              i === index
+                ? 'z-10'
+                : Math.abs(i - index) === 1
+                  ? 'z-0 opacity-50 scale-75'
+                  : 'z-0 opacity-0 scale-75 pointer-events-none',
+            )}
+            style={{ left: i * STEP, top: 0, width: CARD_W, height: CARD_H }}
+          >
+            <BuskingCard
+              variant='lg'
+              item={item}
+              onClick={() => {
+                if (i !== index) {
+                  setIndex(i);
+                } else {
+                  window.location.href = dynamic.liveRoom(item.id, item.status);
+                }
+              }}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* 이전 버튼 */}
+      {index > 0 && (
+        <button
+          type='button'
+          onClick={prev}
+          aria-label='이전'
+          className='absolute top-1/2 -translate-x-1/2 -translate-y-1/2 z-20 size-12 rounded-full bg-white flex items-center justify-center shadow-lg'
+          style={{ left: `calc(50% - ${CARD_W / 2 + 48}px)` }}
+        >
+          <IcArrowRight className='rotate-180' />
+        </button>
+      )}
+
+      {/* 다음 버튼 */}
+      {index < items.length - 1 && (
+        <button
+          type='button'
+          onClick={next}
+          aria-label='다음'
+          className='absolute top-1/2 -translate-x-1/2 -translate-y-1/2 z-20 size-12 rounded-full bg-white flex items-center justify-center shadow-lg'
+          style={{ left: `calc(50% + ${CARD_W / 2 + 48}px)` }}
+        >
+          <IcArrowRight />
+        </button>
+      )}
+    </div>
+  );
 };
 
 export default BuskingCarousel;

--- a/frontend/apps/client/src/widgets/busking-list/ui/BuskingSection.tsx
+++ b/frontend/apps/client/src/widgets/busking-list/ui/BuskingSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { cn } from '@/shared/lib/cn';
+import { useNavigate } from '@/shared/lib/navigation';
 import { BuskingCard } from '@/entities/busking/ui';
 import type { BuskingUiType } from '@/entities/busking/model/types';
 
@@ -23,6 +24,8 @@ const BuskingSection = ({
   px = 8,
   onItemClick,
 }: BuskingSectionProps) => {
+  const { go, dynamic } = useNavigate();
+
   if (!items.length) return null;
 
   return (
@@ -43,7 +46,10 @@ const BuskingSection = ({
             key={item.id}
             variant={cardVariant}
             item={item}
-            onClick={() => onItemClick?.(item)}
+            onClick={() => {
+              if (onItemClick) onItemClick(item);
+              else go(dynamic.liveRoom(item.id, item.status));
+            }}
           />
         ))}
       </div>


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #206


## 📤 Tasks
<!-- 해당 PR에 대한 작업 내용을 작성해주세요. -->
버스킹 관련 캐러셀 UI를 구현하고, 라이브 룸에서 다음 곡 이동 및 종료 요청 흐름을 개선했습니다.

- 버스킹 목록 캐러셀을 구현했습니다.
  - 양옆 카드는 작게 보이도록 scale / opacity 애니메이션을 적용했습니다.

- 스트리머 라이브 룸의 셋리스트 캐러셀을 구현했습니다.
  - 기존 `다음 곡으로` 버튼 영역을 캐러셀 UI로 변경했습니다.
  - 현재 이전 곡으로의 이동 기능이 없기 때문에 다음 버튼만 구현한 상황입니다.

<br/>

## 📸 Screenshot
<!-- 관련 스크린샷을 첨부해주세요. -->
https://github.com/user-attachments/assets/38bdafa2-4267-4890-bb81-6e339a12667e

https://github.com/user-attachments/assets/022d4901-b964-4da9-a90e-6dde7fd4fc31


<br/>

## 💌 To Reviewer
<!-- 리뷰어가 집중해주면 좋을 부분/논의할 부분이 있다면 작성해주세요. -->

<br/>
