### PR TITLE
Fix(client): 버스킹 소켓 이벤트 처리 정리

### DIFF
--- a/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
+++ b/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
@@ -31,6 +31,7 @@ import {
   useEndBuskingRoom,
   useJoinBuskingRoom,
   useAdvanceSetlist,
+  useInvalidateBuskingRoom,
   BUSKING_STATUS,
 } from '@/entities/busking';
 import type { ChatMessageType } from '@/entities/busking';
@@ -66,8 +67,10 @@ const BuskingViewerPage = () => {
   const { mutateAsync: joinRoom } = useJoinBuskingRoom();
   const { mutate: advanceSetlist, isPending: isAdvancing } = useAdvanceSetlist();
 
+  const invalidateBuskingRoom = useInvalidateBuskingRoom();
   const isStreamer = !isRecord && !!me && !!room && me.id === room.host_id;
   const sessionEndedRef = useRef(false);
+  const songIndexRef = useRef<number | undefined>(undefined);
 
   useEffect(() => {
     if (
@@ -122,7 +125,12 @@ const BuskingViewerPage = () => {
   }, [isRecord, room?.ended_at]);
 
   const handleMessage = useCallback(
-    (payload: { userId: string; nickname: string; profileImg?: string | null; message: string }) => {
+    (payload: {
+      userId: string;
+      nickname: string;
+      profileImg?: string | null;
+      message: string;
+    }) => {
       console.log('[Chat] WS 수신 CHAT_MESSAGE', payload);
       setMessages((prev) => [
         ...prev,
@@ -139,7 +147,7 @@ const BuskingViewerPage = () => {
 
   const currentSong = room?.setlist?.find((s) => s.isCurrent);
 
-  const { endLive, sendMessage, sendVote } = useBuskingSocket({
+  const { sendMessage, sendReaction } = useBuskingSocket({
     roomId,
     enabled: !!room,
     onLiveEnd: () => {
@@ -147,7 +155,16 @@ const BuskingViewerPage = () => {
       if (!isStreamer && !isRecord) viewerEndModal.openModal();
     },
     onMessage: handleMessage,
-    onStateUpdate: ({ viewerCount }) => setViewerCount(viewerCount),
+    onStateUpdate: ({ currentSongIndex, viewerCount }) => {
+      setViewerCount(viewerCount);
+      if (
+        songIndexRef.current !== undefined &&
+        songIndexRef.current !== currentSongIndex
+      ) {
+        invalidateBuskingRoom(roomId);
+      }
+      songIndexRef.current = currentSongIndex;
+    },
   });
 
   const handleSend = useCallback(
@@ -172,10 +189,9 @@ const BuskingViewerPage = () => {
     endModal.openModal();
   };
 
-  // 스트리머: 모달에서 확인 → 소켓 종료 후 결과 페이지
+  // 스트리머: 모달에서 확인 → REST로 방 종료
   const handleConfirmEndLive = () => {
     if (isEndingRoom) return;
-    endLive();
     endRoom(roomId, {
       onSuccess: () => go(dynamic.liveRoomEnd(roomId, 'live')),
     });
@@ -267,7 +283,7 @@ const BuskingViewerPage = () => {
               <VotePanel
                 timeLeft={voteTimeLeft}
                 songId={currentSong?.id}
-                onVote={sendVote}
+                onVote={sendReaction}
               />
             </div>
           )}

--- a/frontend/apps/client/src/entities/busking/index.ts
+++ b/frontend/apps/client/src/entities/busking/index.ts
@@ -9,6 +9,7 @@ export {
   useEndBuskingRoom,
   useJoinBuskingRoom,
   useAdvanceSetlist,
+  useInvalidateBuskingRoom,
   useMyBuskingHistory,
 } from './model/queries';
 export type {

--- a/frontend/apps/client/src/entities/busking/model/queries.ts
+++ b/frontend/apps/client/src/entities/busking/model/queries.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { buskingApi } from '../api/buskingApi';
 import { queryKeys } from '@/shared/api/queryKeys';
@@ -89,6 +90,16 @@ export const useAdvanceSetlist = () => {
     onSuccess: (_data, roomId) =>
       queryClient.invalidateQueries({ queryKey: queryKeys.buskingRoom(roomId) }),
   });
+};
+
+// 버스킹 방 데이터 수동 무효화
+export const useInvalidateBuskingRoom = () => {
+  const queryClient = useQueryClient();
+  return useCallback(
+    (roomId: string) =>
+      queryClient.invalidateQueries({ queryKey: queryKeys.buskingRoom(roomId) }),
+    [queryClient],
+  );
 };
 
 // GET: 내 버스킹 기록 조회

--- a/frontend/apps/client/src/features/busking/hooks/useBuskingSocket.ts
+++ b/frontend/apps/client/src/features/busking/hooks/useBuskingSocket.ts
@@ -2,25 +2,31 @@ import { useEffect, useRef, useCallback } from 'react';
 import { tokenStore } from '@/shared/api/tokenStore';
 
 type BuskingSocketEvent =
-  | { type: 'live_end' }
   | { type: 'session_ended' }
-  | { type: 'chat'; user_id: string; nickname: string; profile_img?: string | null; message: string }
-  | { type: 'new_chat'; payload: { userId: string; nickname: string; profileImg?: string | null; message: string } }
-  | { type: 'vote'; payload: { songId: string; count: number } }
-  | { type: 'join'; payload: { userId: string; nickname: string } }
-  | { type: 'leave'; payload: { userId: string; nickname: string } }
-  | { type: 'state_update'; current_song_index: number; viewer_count: number };
+  | {
+      type: 'chat';
+      user_id: string;
+      nickname: string;
+      profile_img?: string | null;
+      message: string;
+    }
+  | { type: 'reaction_update'; match: number; mismatch: number }
+  | { type: 'state_update'; current_song_index: number; viewer_count: number }
+  | { type: 'error'; detail: string };
 
-type ChatPayload = { userId: string; nickname: string; profileImg?: string | null; message: string };
+type ChatPayload = {
+  userId: string;
+  nickname: string;
+  profileImg?: string | null;
+  message: string;
+};
 
 interface UseBuskingSocketOptions {
   roomId: string;
   enabled?: boolean;
   onLiveEnd?: () => void;
   onMessage?: (payload: ChatPayload) => void;
-  onVote?: (payload: { songId: string; count: number }) => void;
-  onJoin?: (payload: { userId: string; nickname: string }) => void;
-  onLeave?: (payload: { userId: string; nickname: string }) => void;
+  onReactionUpdate?: (payload: { match: number; mismatch: number }) => void;
   onStateUpdate?: (payload: { currentSongIndex: number; viewerCount: number }) => void;
 }
 
@@ -31,9 +37,7 @@ export const useBuskingSocket = ({
   enabled = true,
   onLiveEnd,
   onMessage,
-  onVote,
-  onJoin,
-  onLeave,
+  onReactionUpdate,
   onStateUpdate,
 }: UseBuskingSocketOptions) => {
   const wsRef = useRef<WebSocket | null>(null);
@@ -42,9 +46,7 @@ export const useBuskingSocket = ({
 
   const onLiveEndRef = useRef(onLiveEnd);
   const onMessageRef = useRef(onMessage);
-  const onVoteRef = useRef(onVote);
-  const onJoinRef = useRef(onJoin);
-  const onLeaveRef = useRef(onLeave);
+  const onReactionUpdateRef = useRef(onReactionUpdate);
   const onStateUpdateRef = useRef(onStateUpdate);
 
   useEffect(() => {
@@ -54,14 +56,8 @@ export const useBuskingSocket = ({
     onMessageRef.current = onMessage;
   }, [onMessage]);
   useEffect(() => {
-    onVoteRef.current = onVote;
-  }, [onVote]);
-  useEffect(() => {
-    onJoinRef.current = onJoin;
-  }, [onJoin]);
-  useEffect(() => {
-    onLeaveRef.current = onLeave;
-  }, [onLeave]);
+    onReactionUpdateRef.current = onReactionUpdate;
+  }, [onReactionUpdate]);
   useEffect(() => {
     onStateUpdateRef.current = onStateUpdate;
   }, [onStateUpdate]);
@@ -89,7 +85,6 @@ export const useBuskingSocket = ({
         const event: BuskingSocketEvent = JSON.parse(e.data);
 
         switch (event.type) {
-          case 'live_end':
           case 'session_ended':
             onLiveEndRef.current?.();
             break;
@@ -101,17 +96,11 @@ export const useBuskingSocket = ({
               message: event.message,
             });
             break;
-          case 'new_chat':
-            onMessageRef.current?.(event.payload);
-            break;
-          case 'vote':
-            onVoteRef.current?.(event.payload);
-            break;
-          case 'join':
-            onJoinRef.current?.(event.payload);
-            break;
-          case 'leave':
-            onLeaveRef.current?.(event.payload);
+          case 'reaction_update':
+            onReactionUpdateRef.current?.({
+              match: event.match,
+              mismatch: event.mismatch,
+            });
             break;
           case 'state_update':
             onStateUpdateRef.current?.({
@@ -155,12 +144,10 @@ export const useBuskingSocket = ({
     [send],
   );
 
-  const endLive = useCallback(() => send({ type: 'live_end' }), [send]);
-
-  const sendVote = useCallback(
-    (songId: string) => send({ type: 'vote', payload: { songId } }),
+  const sendReaction = useCallback(
+    (value: 'match' | 'mismatch') => send({ type: 'reaction', value }),
     [send],
   );
 
-  return { sendMessage, endLive, sendVote };
+  return { sendMessage, sendReaction };
 };

--- a/frontend/apps/client/src/features/busking/ui/LiveStartModal.tsx
+++ b/frontend/apps/client/src/features/busking/ui/LiveStartModal.tsx
@@ -8,7 +8,6 @@ import { useThumbnail } from '@/shared/hooks';
 import { LiveStartStep1 } from './LiveStartStep1';
 import { LiveStartStep2 } from './LiveStartStep2';
 
-import { getApiErrorMessage } from '@/shared/api/apiError';
 import type { SongUiType } from '@/entities/song/model/types';
 import {
   useCreateBuskingRoom,
@@ -58,7 +57,11 @@ const LiveStartModal = ({ open, onClose }: LiveStartModalProps) => {
       // 썸네일이 있으면 presigned URL로 S3 업로드
       if (thumbnail?.file) {
         const { upload_url, s3_url } = await getPresignedUrl();
-        await fetch(upload_url, { method: 'PUT', body: thumbnail.file });
+        await fetch(upload_url, {
+          method: 'PUT',
+          body: thumbnail.file,
+          headers: { 'Content-Type': 'image/jpeg' },
+        });
         thumbnailUrl = s3_url;
       }
 
@@ -82,8 +85,9 @@ const LiveStartModal = ({ open, onClose }: LiveStartModalProps) => {
       );
 
       go(dynamic.liveRoom(room.id, 'live'));
-    } catch (err) {
-      alert(getApiErrorMessage(err, '버스킹 시작에 실패했습니다.'));
+    } catch (error) {
+      alert('버스킹 시작에 실패했습니다.');
+      console.error(error);
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/apps/client/src/features/busking/ui/VotePanel.tsx
+++ b/frontend/apps/client/src/features/busking/ui/VotePanel.tsx
@@ -1,23 +1,27 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { IcThumbsDown, IcThumbsUp } from '@/shared/assets/icons';
 
-type VoteType = 'up' | 'down' | null;
+type VoteType = 'match' | 'mismatch' | null;
 
 type VotePanelProps = {
   timeLeft?: string;
   songId?: string;
-  onVote?: (songId: string) => void;
+  onVote?: (value: 'match' | 'mismatch') => void;
 };
 
 const VotePanel = ({ timeLeft, songId, onVote }: VotePanelProps) => {
   const [vote, setVote] = useState<VoteType>(null);
 
-  const handleVote = (type: VoteType) => {
-    if (vote || !songId || !onVote) return;
+  useEffect(() => {
+    setVote(null);
+  }, [songId]);
+
+  const handleVote = (type: 'match' | 'mismatch') => {
+    if (type === vote || !onVote) return;
     setVote(type);
-    onVote(songId);
+    onVote(type);
   };
 
   return (
@@ -33,16 +37,16 @@ const VotePanel = ({ timeLeft, songId, onVote }: VotePanelProps) => {
 
       <div className='flex gap-2'>
         <button
-          onClick={() => handleVote('up')}
-          disabled={!!vote}
+          onClick={() => handleVote('match')}
+          disabled={vote === 'match'}
           className='p-3 flex flex-col items-center gap-0.5 w-22.5 rounded-10 bg-yellow-500-30 disabled:opacity-50'
         >
           <IcThumbsUp />
           <span className='typo-12r text-brand'>어울려요</span>
         </button>
         <button
-          onClick={() => handleVote('down')}
-          disabled={!!vote}
+          onClick={() => handleVote('mismatch')}
+          disabled={vote === 'mismatch'}
           className='p-3 flex flex-col items-center gap-0.5 w-22.5 rounded-10 bg-white-20 disabled:opacity-50'
         >
           <IcThumbsDown />


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #219


## 📤 Tasks
<!-- 해당 PR에 대한 작업 내용을 작성해주세요. -->
- 버스킹 소켓 이벤트 처리 정리
  - 실제 백엔드 프로토콜에 맞게 수신 이벤트 타입 수정
  - 사용하지 않는 `join`, `leave`, `new_chat`, `live_end`, `vote` 이벤트 처리 제거
  - `reaction_update`, `state_update`, `session_ended`, `error` 이벤트 기준으로 타입 정리

- 시청자 현재 곡 갱신 버그 수정
  - `state_update` 수신 시 `currentSongIndex`를 추적하도록 수정
  - 현재 곡 인덱스가 변경되면 버스킹 방 쿼리를 무효화하도록 처리
  - 호스트가 곡을 넘겼을 때 시청자 화면의 현재 곡 정보가 갱신되도록 수정

- 투표/리액션 기능 보완
  - 기존 `vote` 메시지 전송을 백엔드 프로토콜에 맞는 `reaction` 메시지 전송으로 변경
  - 투표 타입을 `match`, `mismatch` 기준으로 정리
  - 곡이 변경될 때 선택한 투표 상태가 초기화되도록 수정

- 라이브 종료 처리 정리
  - 백엔드가 처리하지 않는 WS 기반 `endLive` 전송 로직 제거
  - 실제 라이브 종료는 REST `endRoom` 요청으로만 처리하도록 정리

- 버스킹 시작 이미지 업로드 수정
  - presigned URL 이미지 업로드 시 `Content-Type: image/jpeg` 헤더 추가
  - 버스킹 시작 실패 시 콘솔에 에러를 출력하도록 수정

<br/>

## 📸 Screenshot
<!-- 관련 스크린샷을 첨부해주세요. -->

<br/>

## 💌 To Reviewer
<!-- 리뷰어가 집중해주면 좋을 부분/논의할 부분이 있다면 작성해주세요. -->

<br/>
