### PR TITLE
Fix(client): 카카오 로그인 시 인가 코드 중복 사용 에러 수정

### DIFF
--- a/frontend/apps/client/src/entities/auth/hooks/useKakaoLoginCallback.ts
+++ b/frontend/apps/client/src/entities/auth/hooks/useKakaoLoginCallback.ts
@@ -1,21 +1,22 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from '@/shared/lib/navigation';
 import { useLogin } from '../model/queries';
+
+let isProcessing = false;
 
 export const useKakaoLoginCallback = () => {
   const { go, ROUTES } = useNavigate();
   const { mutate: login } = useLogin();
-  const hasRunRef = useRef(false);
 
   useEffect(() => {
-    if (hasRunRef.current) return;
+    if (isProcessing) return;
 
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code');
 
     if (!code) return;
 
-    hasRunRef.current = true;
+    isProcessing = true;
 
     const getKakaoToken = async (authCode: string) => {
       const response = await fetch('https://kauth.kakao.com/oauth/token', {

--- a/frontend/apps/client/src/entities/auth/hooks/useKakaoLoginCallback.ts
+++ b/frontend/apps/client/src/entities/auth/hooks/useKakaoLoginCallback.ts
@@ -13,8 +13,17 @@ export const useKakaoLoginCallback = () => {
 
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code');
+    const state = params.get('state');
 
-    if (!code) return;
+    if (!code || !state) return;
+
+    const savedState = localStorage.getItem('kakao_oauth_state');
+    if (state !== savedState) {
+      console.error('Kakao OAuth state 불일치');
+      go(ROUTES.login.root);
+      return;
+    }
+    localStorage.removeItem('kakao_oauth_state');
 
     isProcessing = true;
 
@@ -61,11 +70,15 @@ export const useKakaoLoginCallback = () => {
             },
             onError: (error) => {
               console.error('로그인 실패:', error);
+              isProcessing = false;
+              go(ROUTES.login.root);
             },
           },
         );
       } catch (error) {
         console.error('로그인 에러:', error);
+        isProcessing = false;
+        go(ROUTES.login.root);
       }
     };
 

--- a/frontend/apps/client/src/entities/auth/hooks/useNaverLoginCallback.ts
+++ b/frontend/apps/client/src/entities/auth/hooks/useNaverLoginCallback.ts
@@ -1,14 +1,15 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from '@/shared/lib/navigation';
 import { useLogin } from '../model/queries';
+
+let isProcessing = false;
 
 export const useNaverLoginCallback = () => {
   const { go, ROUTES } = useNavigate();
   const { mutate: login } = useLogin();
-  const hasRunRef = useRef(false);
 
   useEffect(() => {
-    if (hasRunRef.current) return;
+    if (isProcessing) return;
 
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code');
@@ -24,7 +25,7 @@ export const useNaverLoginCallback = () => {
     }
     localStorage.removeItem('naver_oauth_state');
 
-    hasRunRef.current = true;
+    isProcessing = true;
 
     const getNaverToken = async (authCode: string, oauthState: string) => {
       const response = await fetch('/api/auth/naver/token', {
@@ -66,11 +67,15 @@ export const useNaverLoginCallback = () => {
             },
             onError: (error) => {
               console.error('로그인 실패:', error);
+              isProcessing = false;
+              go(ROUTES.login.root);
             },
           },
         );
       } catch (error) {
         console.error('로그인 에러:', error);
+        isProcessing = false;
+        go(ROUTES.login.root);
       }
     };
 


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #221


## 📤 Tasks
<!-- 해당 PR에 대한 작업 내용을 작성해주세요. -->
- `useRef`를 모듈 레벨 `isProcessing` 변수로 교체하여 React StrictMode 재마운트 시 인가 코드 중복 사용 방지
- 카카오 콜백에 state(CSRF 토큰) 검증 로직 추가
- 에러 발생 시 로그인 페이지로 리다이렉트 처리 추가

<br/>

## 📸 Screenshot
<!-- 관련 스크린샷을 첨부해주세요. -->

<br/>

## 💌 To Reviewer
<!-- 리뷰어가 집중해주면 좋을 부분/논의할 부분이 있다면 작성해주세요. -->

<br/>
