### PR TITLE
Feat(server): 폴더 관리 기능 고도화

### DIFF
--- a/backend/app/routers/library.py
+++ b/backend/app/routers/library.py
@@ -17,7 +17,7 @@ from app.models.archive import Archive
 from app.models.recommendation import Recommendation
 from app.models.song import Song as SongModel
 from app.schemas.library import (
-    FolderCreate, FolderResponse,
+    FolderCreate, FolderUpdate, FolderResponse,
     WishlistItemCreate, WishlistItemResponse,
 )
 from app.schemas.archive import ArchiveCreate, ArchiveUpdate, ArchiveResponse
@@ -34,19 +34,50 @@ async def get_folders(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    rows = (await db.execute(
+    # 폴더 목록 + item_count
+    folder_rows = (await db.execute(
         select(Folder, func.count(WishlistItem.id).label("item_count"))
         .outerjoin(WishlistItem, WishlistItem.folder_id == Folder.id)
         .where(Folder.user_id == current_user.id)
         .group_by(Folder.id)
         .order_by(Folder.created_at)
     )).all()
+
+    # 폴더별 썸네일: 최신 순 최대 4개 album_image (ROW_NUMBER 윈도우 단일 쿼리)
+    wi_ranked = (
+        select(
+            WishlistItem.folder_id,
+            WishlistItem.song_data["album_image"].astext.label("album_image"),
+            func.row_number().over(
+                partition_by=WishlistItem.folder_id,
+                order_by=WishlistItem.created_at.desc(),
+            ).label("rn"),
+        )
+        .where(
+            WishlistItem.user_id == current_user.id,
+            WishlistItem.folder_id.isnot(None),
+        )
+        .subquery()
+    )
+    thumb_rows = (await db.execute(
+        select(wi_ranked.c.folder_id, wi_ranked.c.album_image)
+        .where(wi_ranked.c.rn <= 4)
+        .order_by(wi_ranked.c.folder_id, wi_ranked.c.rn)
+    )).all()
+
+    thumbnails_by_folder: dict[str, list[str]] = defaultdict(list)
+    for row in thumb_rows:
+        if row.album_image:
+            thumbnails_by_folder[str(row.folder_id)].append(row.album_image)
+
     return [
         FolderResponse(
             id=f.id, user_id=f.user_id, name=f.name,
-            is_system=f.is_system, created_at=f.created_at, item_count=cnt,
+            is_system=f.is_system, created_at=f.created_at,
+            item_count=cnt,
+            thumbnails=thumbnails_by_folder.get(str(f.id), []),
         )
-        for f, cnt in rows
+        for f, cnt in folder_rows
     ]
 
 
@@ -63,6 +94,32 @@ async def create_folder(
     return FolderResponse(
         id=folder.id, user_id=folder.user_id, name=folder.name,
         is_system=folder.is_system, created_at=folder.created_at, item_count=0,
+    )
+
+
+@router.patch("/folders/{folder_id}", response_model=FolderResponse)
+async def rename_folder(
+    folder_id: UUID,
+    body: FolderUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    folder = (await db.execute(
+        select(Folder).where(Folder.id == folder_id, Folder.user_id == current_user.id)
+    )).scalar_one_or_none()
+    if not folder:
+        raise HTTPException(status_code=404, detail="폴더를 찾을 수 없습니다.")
+    if folder.is_system:
+        raise HTTPException(status_code=400, detail="시스템 폴더는 이름을 변경할 수 없습니다.")
+    folder.name = body.name.strip()
+    await db.commit()
+    await db.refresh(folder)
+    cnt = (await db.execute(
+        select(func.count(WishlistItem.id)).where(WishlistItem.folder_id == folder.id)
+    )).scalar_one()
+    return FolderResponse(
+        id=folder.id, user_id=folder.user_id, name=folder.name,
+        is_system=folder.is_system, created_at=folder.created_at, item_count=cnt,
     )
 
 

--- a/backend/app/schemas/library.py
+++ b/backend/app/schemas/library.py
@@ -1,6 +1,6 @@
 """Library 스키마 - Folder & Wishlist"""
 from pydantic import BaseModel
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 from datetime import datetime
 
@@ -11,6 +11,10 @@ class FolderCreate(BaseModel):
     name: str
 
 
+class FolderUpdate(BaseModel):
+    name: str
+
+
 class FolderResponse(BaseModel):
     id: UUID
     user_id: UUID
@@ -18,6 +22,7 @@ class FolderResponse(BaseModel):
     is_system: bool
     created_at: datetime
     item_count: int = 0
+    thumbnails: List[str] = []   # 최신 찜 항목 앨범 커버 최대 4개
 
     model_config = {"from_attributes": True}
 


### PR DESCRIPTION
## 📌 Related Issue
* Closed #223 

## 📤 Tasks
- **폴더 응답 및 요청 스키마 정의 (`schemas/library.py`)**
  - `FolderResponse`: 썸네일 리스트(`thumbnails`) 필드 추가
  - `FolderUpdate`: 이름 변경을 위한 전용 DTO 추가
- **폴더 조회 및 수정 로직 구현 (`library.py`)**
  - **썸네일 최적화:** `PARTITION BY` 서브쿼리를 사용하여 N+1 문제 없이 폴더별 최신 앨범 아트 4개를 한 번에 가져오도록 SQL 최적화
  - **PATCH 엔드포인트:** 지정된 `folder_id`의 이름을 변경하되, 시스템 예약 폴더는 수정할 수 없도록 검증 로직 반영
- **예외 처리**
  - 시스템 폴더 수정 제한 및 존재하지 않는 폴더 접근 시 에러 핸들링

## 📸 Screenshot
<br/>

## 💌 To Reviewer
- 동일한 파일(`library.py`, `schemas/library.py`) 내에서 발생하는 작업이라 하나의 PR로 통합했습니다.
- 특히 썸네일 조회의 경우, 폴더가 많아질 때를 대비해 서브쿼리 효율성을 신경 썼으니 쿼리문 위주로 봐주시면 좋을 것 같아요!
- 시스템 폴더 수정 차단 로직이 기획된 의도대로 작동하는지도 확인 부탁드립니다.