### PR TITLE
Feat(server): 버스킹 곡별 투표 결과 집계 추가

### DIFF
--- a/backend/app/models/busking.py
+++ b/backend/app/models/busking.py
@@ -46,6 +46,7 @@ class BuskingReaction(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     room_id = Column(UUID(as_uuid=True), ForeignKey("busking_rooms.id", ondelete="CASCADE"), nullable=False, index=True)
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    song_index = Column(Integer, nullable=True)        # 반응 시점의 current_song_index (0-based)
     value = Column(String, nullable=False)             # "match" | "mismatch"
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/app/routers/busking.py
+++ b/backend/app/routers/busking.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect, status
-from sqlalchemy import func, select
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -416,6 +416,36 @@ async def get_result(room_id: UUID, db: AsyncSession = Depends(get_db)):
         )
 
     setlist = await _get_setlist(db, room_id)
+
+    # 곡별 match/mismatch 집계
+    per_song_rows = (await db.execute(
+        select(
+            BuskingReaction.song_index,
+            func.sum(case((BuskingReaction.value == "match", 1), else_=0)).label("match_count"),
+            func.sum(case((BuskingReaction.value == "mismatch", 1), else_=0)).label("mismatch_count"),
+        )
+        .where(
+            BuskingReaction.room_id == room_id,
+            BuskingReaction.song_index.isnot(None),
+        )
+        .group_by(BuskingReaction.song_index)
+        .order_by(BuskingReaction.song_index)
+    )).all()
+
+    per_song_map = {
+        row.song_index: {"match": int(row.match_count), "mismatch": int(row.mismatch_count)}
+        for row in per_song_rows
+    }
+    per_song = [
+        {
+            "song_index": s.order_index,
+            "title": s.title,
+            "artist": s.artist,
+            **per_song_map.get(s.order_index, {"match": 0, "mismatch": 0}),
+        }
+        for s in setlist
+    ]
+
     return BuskingResultResponse(
         live_id=room.id,
         title=room.title,
@@ -423,7 +453,10 @@ async def get_result(room_id: UUID, db: AsyncSession = Depends(get_db)):
         peak_viewer_count=room.peak_viewer_count,
         total_unique_viewers=room.total_unique_viewers,
         setlist=[SetlistItemResponse.model_validate(s) for s in setlist],
-        reactions={"match": result_row.match_count, "mismatch": result_row.mismatch_count},
+        reactions={
+            "total": {"match": result_row.match_count, "mismatch": result_row.mismatch_count},
+            "per_song": per_song,
+        },
         chat_count=result_row.chat_count,
         started_at=room.started_at,
         ended_at=room.ended_at,
@@ -559,7 +592,12 @@ async def _save_chat(room_id: str, user_id: str, message: str):
 
 async def _save_reaction(room_id: str, user_id: str, value: str):
     async with AsyncSessionLocal() as db:
-        db.add(BuskingReaction(room_id=room_id, user_id=user_id, value=value))
+        song_idx = (await db.execute(
+            select(BuskingRoom.current_song_index).where(BuskingRoom.id == room_id)
+        )).scalar_one_or_none()
+        db.add(BuskingReaction(
+            room_id=room_id, user_id=user_id, value=value, song_index=song_idx
+        ))
         await db.commit()
 
 


### PR DESCRIPTION
## 📌 Related Issue
* Closed #225 

## 📤 Tasks
- **데이터 모델 확장**
  - `models/busking.py`: 리액션과 곡의 관계를 추적하기 위한 인덱스 컬럼 추가
- **실시간 데이터 바인딩**
  - WS를 통한 리액션 수집 시, 실시간 세션 정보에서 `current_song_index`를 조회하여 정확한 곡 위치 기록
- **통계 API 고도화**
  - `get_result` 응답에 곡별 투표 분포 데이터를 포함하여 프론트엔드 시각화 지원
- **DB 마이그레이션**
  - 기존 테이블에 `song_index` 컬럼 추가 완료
  
## 📸 Screenshot
<!-- 썸네일이 포함된 폴더 목록 응답 결과와 폴더명 수정 성공 스크린샷을 첨부해주세요. -->
<br/>

## 💌 To Reviewer