### PR TITLE
Feat(client): 폴더 이름 변경 기능 구현 및 찜 기능 개선

### DIFF
--- a/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
+++ b/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
@@ -61,7 +61,8 @@ const BuskingViewerPage = () => {
 
   const { data: me } = useMe();
   const { data: room } = useBuskingRoom(roomId);
-  const { data: rooms = [] } = useBuskingRooms();
+  const { data: allRooms = [] } = useBuskingRooms();
+  const rooms = allRooms.filter((r) => r.id !== roomId);
   const { mutate: endRoom, isPending: isEndingRoom } = useEndBuskingRoom();
   const { mutateAsync: joinRoom } = useJoinBuskingRoom();
   const { mutate: advanceSetlist, isPending: isAdvancing } = useAdvanceSetlist();

--- a/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
+++ b/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
@@ -48,7 +48,6 @@ const BuskingViewerPage = () => {
   const isRecord = searchParams.get('type') === 'record';
 
   const [messages, setMessages] = useState<ChatMessageType[]>([]);
-  const [showVote] = useState(true);
   const [isLastSong, setIsLastSong] = useState(false);
   const [liveKitCredentials, setLiveKitCredentials] = useState<LiveKitCredentials | null>(
     null,
@@ -216,7 +215,7 @@ const BuskingViewerPage = () => {
       <div className='flex flex-col flex-1 overflow-y-auto scrollbar-hide'>
         {/* 헤더 */}
         <div className='px-9 flex items-center h-26 shrink-0'>
-          <BackButton />
+          <BackButton onClick={() => go(ROUTES.live.root)} />
 
           <div className='ml-5 flex gap-2'>
             <div className='relative size-12 rounded-full bg-gray-600 border border-accent-600 shrink-0 overflow-hidden'>
@@ -278,7 +277,7 @@ const BuskingViewerPage = () => {
           </div>
 
           {/* 투표 패널 */}
-          {showVote && !isStreamer && (
+          {!isStreamer && (
             <div className='absolute bottom-3 right-3'>
               <VotePanel
                 timeLeft={voteTimeLeft}

--- a/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
+++ b/frontend/apps/client/src/app/(main)/live/room/[id]/page.tsx
@@ -130,7 +130,6 @@ const BuskingViewerPage = () => {
       profileImg?: string | null;
       message: string;
     }) => {
-      console.log('[Chat] WS 수신 CHAT_MESSAGE', payload);
       setMessages((prev) => [
         ...prev,
         {
@@ -168,7 +167,6 @@ const BuskingViewerPage = () => {
 
   const handleSend = useCallback(
     (message: string) => {
-      console.log('[Chat] WS 전송', message);
       sendMessage(message);
     },
     [sendMessage],

--- a/frontend/apps/client/src/entities/archive/ui/ArchiveSection.tsx
+++ b/frontend/apps/client/src/entities/archive/ui/ArchiveSection.tsx
@@ -54,6 +54,7 @@ const ArchiveSection = ({ group }: ArchiveSectionProps) => {
                 <SongLikeButton
                   songId={String(song.id)}
                   isLiked={song.isLiked ?? false}
+                  song={song}
                 />
                 <SongBlockMenu songId={String(song.id)} />
               </div>

--- a/frontend/apps/client/src/entities/busking/api/buskingApi.ts
+++ b/frontend/apps/client/src/entities/busking/api/buskingApi.ts
@@ -1,5 +1,6 @@
 import { privateClient } from '@/shared/api/client';
 import type { components } from '@singchronize/api';
+import type { BuskingResultApiType } from '../model/types';
 
 export const buskingApi = {
   // POST: 썸네일 업로드용 presigned URL 발급
@@ -92,7 +93,7 @@ export const buskingApi = {
   // GET: 버스킹 결과 조회
   getResult: async (
     roomId: string,
-  ): Promise<components['schemas']['BuskingResultResponse']> => {
+  ): Promise<BuskingResultApiType> => {
     const { data, error } = await privateClient.GET(
       '/api/v1/busking/rooms/{room_id}/result',
       { params: { path: { room_id: roomId } } },

--- a/frontend/apps/client/src/entities/busking/model/mapper.ts
+++ b/frontend/apps/client/src/entities/busking/model/mapper.ts
@@ -21,7 +21,10 @@ export const toBuskingUi = (room: BuskingRoomApiType): BuskingUiType => ({
   totalViewers: room.total_viewers,
 });
 
-export const toSetlistUi = (item: SetlistItemApiType, currentIndex?: number): SetlistType => ({
+export const toSetlistUi = (
+  item: SetlistItemApiType,
+  currentIndex?: number,
+): SetlistType => ({
   id: item.id,
   rank: item.order_index + 1,
   title: item.title,
@@ -34,7 +37,7 @@ export const toResultItemUi = (
   item: SetlistItemApiType,
   reactions: BuskingResultApiType['reactions'],
 ): BuskingResultItemType => {
-  const votePercent = (reactions as Record<string, number>)[item.id] ?? 0;
+  const votePercent = reactions[item.id] ?? 0;
 
   return {
     id: item.id,

--- a/frontend/apps/client/src/entities/busking/model/types.ts
+++ b/frontend/apps/client/src/entities/busking/model/types.ts
@@ -4,7 +4,12 @@ export type BuskingRoomApiType = components['schemas']['BuskingRoomResponse'];
 export type BuskingRoomDetailApiType = components['schemas']['BuskingRoomDetailResponse'];
 export type BuskingRoomCreateApiType = components['schemas']['BuskingRoomCreateResponse'];
 export type BuskingRoomCreateBody = components['schemas']['BuskingRoomCreate'];
-export type BuskingResultApiType = components['schemas']['BuskingResultResponse'];
+export type BuskingResultApiType = Omit<
+  components['schemas']['BuskingResultResponse'],
+  'reactions'
+> & {
+  reactions: Record<string, number>;
+};
 export type ThumbnailPresignedApiType =
   components['schemas']['ThumbnailPresignedResponse'];
 export type LiveKitJoinApiType = components['schemas']['LiveKitJoinResponse'];

--- a/frontend/apps/client/src/entities/library/api/libraryApi.ts
+++ b/frontend/apps/client/src/entities/library/api/libraryApi.ts
@@ -1,5 +1,11 @@
 import { privateClient } from '@/shared/api/client';
-import type { FolderCreate, WishlistItemCreate, ArchiveCreate, ArchiveUpdate } from '../model/types';
+import type {
+  FolderCreate,
+  FolderUpdate,
+  WishlistItemCreate,
+  ArchiveCreate,
+  ArchiveUpdate,
+} from '../model/types';
 
 export const libraryApi = {
   // GET: 폴더 목록 조회
@@ -12,6 +18,19 @@ export const libraryApi = {
   // POST: 폴더 생성
   createFolder: async (body: FolderCreate) => {
     const { data, error } = await privateClient.POST('/api/v1/library/folders', { body });
+    if (error) throw error;
+    return data;
+  },
+
+  // PATCH: 폴더 이름 변경
+  renameFolder: async (folderId: string, body: FolderUpdate) => {
+    const { data, error } = await privateClient.PATCH(
+      '/api/v1/library/folders/{folder_id}',
+      {
+        params: { path: { folder_id: folderId } },
+        body,
+      },
+    );
     if (error) throw error;
     return data;
   },
@@ -35,7 +54,9 @@ export const libraryApi = {
 
   // POST: 위시리스트 곡 추가
   addWishlistItem: async (body: WishlistItemCreate) => {
-    const { data, error } = await privateClient.POST('/api/v1/library/wishlist', { body });
+    const { data, error } = await privateClient.POST('/api/v1/library/wishlist', {
+      body,
+    });
     if (error) throw error;
     return data;
   },
@@ -64,10 +85,13 @@ export const libraryApi = {
 
   // PATCH: 보컬 기록 수정
   updateHistory: async (archiveId: string, body: ArchiveUpdate) => {
-    const { data, error } = await privateClient.PATCH('/api/v1/library/history/{archive_id}', {
-      params: { path: { archive_id: archiveId } },
-      body,
-    });
+    const { data, error } = await privateClient.PATCH(
+      '/api/v1/library/history/{archive_id}',
+      {
+        params: { path: { archive_id: archiveId } },
+        body,
+      },
+    );
     if (error) throw error;
     return data;
   },

--- a/frontend/apps/client/src/entities/library/index.ts
+++ b/frontend/apps/client/src/entities/library/index.ts
@@ -3,6 +3,7 @@ export {
   useFolders,
   useCreateFolder,
   useDeleteFolder,
+  useRenameFolder,
   useWishlist,
   useAddWishlistItem,
   useDeleteWishlistItem,

--- a/frontend/apps/client/src/entities/library/model/mapper.ts
+++ b/frontend/apps/client/src/entities/library/model/mapper.ts
@@ -52,7 +52,7 @@ export const toFavoriteFolderUi = (
 ): FavoriteFolderUiType => ({
   id: folder.id,
   name: folder.name,
-  coverImages: [],
+  coverImages: folder.thumbnails,
   songCount: folder.item_count,
   updatedAt: formatUpdatedAtLabel(folder.created_at),
 });

--- a/frontend/apps/client/src/entities/library/model/queries.ts
+++ b/frontend/apps/client/src/entities/library/model/queries.ts
@@ -116,6 +116,7 @@ export const useAddWishlistItem = () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.wishlist(body.folder_id ?? undefined),
       });
+      queryClient.invalidateQueries({ queryKey: queryKeys.folders });
     },
   });
 };
@@ -147,7 +148,10 @@ export const useDeleteWishlistItem = () => {
         queryClient.setQueryData(key, data);
       });
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['library', 'wishlist'] }),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['library', 'wishlist'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.folders });
+    },
   });
 };
 

--- a/frontend/apps/client/src/entities/library/model/queries.ts
+++ b/frontend/apps/client/src/entities/library/model/queries.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { libraryApi } from '../api/libraryApi';
 import type {
   FolderCreate,
+  FolderUpdate,
   WishlistItemCreate,
   FavoriteFolderApiType,
   FavoriteSongApiType,
@@ -45,6 +46,29 @@ export const useDeleteFolder = () => {
       return { previous };
     },
     onError: (_err, _folderId, context) => {
+      queryClient.setQueryData(queryKeys.folders, context?.previous);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.folders }),
+  });
+};
+
+// PATCH: 폴더 이름 변경
+export const useRenameFolder = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ folderId, body }: { folderId: string; body: FolderUpdate }) =>
+      libraryApi.renameFolder(folderId, body),
+    onMutate: async ({ folderId, body }) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.folders });
+      const previous = queryClient.getQueryData<FavoriteFolderApiType[]>(
+        queryKeys.folders,
+      );
+      queryClient.setQueryData<FavoriteFolderApiType[]>(queryKeys.folders, (old = []) =>
+        old.map((f) => (f.id === folderId ? { ...f, name: body.name } : f)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
       queryClient.setQueryData(queryKeys.folders, context?.previous);
     },
     onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.folders }),

--- a/frontend/apps/client/src/entities/library/model/queries.ts
+++ b/frontend/apps/client/src/entities/library/model/queries.ts
@@ -4,6 +4,7 @@ import type {
   FolderCreate,
   WishlistItemCreate,
   FavoriteFolderApiType,
+  FavoriteSongApiType,
   HistoryItemApiType,
   ArchiveCreate,
   ArchiveUpdate,
@@ -63,7 +64,35 @@ export const useAddWishlistItem = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (body: WishlistItemCreate) => libraryApi.addWishlistItem(body),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['library', 'wishlist'] }),
+    onMutate: async (body) => {
+      const wishlistKey = queryKeys.wishlist(body.folder_id ?? undefined);
+      await queryClient.cancelQueries({ queryKey: wishlistKey });
+
+      const previous = queryClient.getQueryData<FavoriteSongApiType[]>(wishlistKey);
+
+      const tempItem: FavoriteSongApiType = {
+        id: `temp-${crypto.randomUUID()}`,
+        user_id: '',
+        folder_id: body.folder_id ?? null,
+        song_data: body.song_data,
+        created_at: new Date().toISOString(),
+      };
+
+      queryClient.setQueryData<FavoriteSongApiType[]>(wishlistKey, (old = []) => [
+        tempItem,
+        ...old,
+      ]);
+
+      return { previous, wishlistKey };
+    },
+    onError: (_err, _body, context) => {
+      if (context) queryClient.setQueryData(context.wishlistKey, context.previous);
+    },
+    onSettled: (_data, _err, body) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.wishlist(body.folder_id ?? undefined),
+      });
+    },
   });
 };
 
@@ -72,7 +101,29 @@ export const useDeleteWishlistItem = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (itemId: string) => libraryApi.deleteWishlistItem(itemId),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['library', 'wishlist'] }),
+    onMutate: async (itemId) => {
+      await queryClient.cancelQueries({ queryKey: ['library', 'wishlist'] });
+
+      const allCaches = queryClient.getQueriesData<FavoriteSongApiType[]>({
+        queryKey: ['library', 'wishlist'],
+      });
+
+      allCaches.forEach(([key, data]) => {
+        if (!data) return;
+        queryClient.setQueryData<FavoriteSongApiType[]>(
+          key,
+          data.filter((item) => item.id !== itemId),
+        );
+      });
+
+      return { allCaches };
+    },
+    onError: (_err, _itemId, context) => {
+      context?.allCaches.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['library', 'wishlist'] }),
   });
 };
 

--- a/frontend/apps/client/src/entities/library/model/types.ts
+++ b/frontend/apps/client/src/entities/library/model/types.ts
@@ -4,6 +4,7 @@ import { HistoryTagType } from './tags';
 export type HistoryItemApiType = components['schemas']['ArchiveResponse'];
 export type FavoriteFolderApiType = components['schemas']['FolderResponse'];
 export type FolderCreate = components['schemas']['FolderCreate'];
+export type FolderUpdate = components['schemas']['FolderUpdate'];
 export type FavoriteSongApiType = components['schemas']['WishlistItemResponse'];
 export type WishlistItemCreate = components['schemas']['WishlistItemCreate'];
 export type ArchiveCreate = components['schemas']['ArchiveCreate'];

--- a/frontend/apps/client/src/entities/library/ui/FavoriteFolderCard.tsx
+++ b/frontend/apps/client/src/entities/library/ui/FavoriteFolderCard.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useRef, useState } from 'react';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  InputField,
 } from '@singchronize/ui';
 import { IcMore } from '@/shared/assets/icons';
 import { cn } from '@/shared/lib/cn';
@@ -14,29 +16,63 @@ import FavoriteFolderCover from './FavoriteFolderCover';
 interface FavoriteFolderCardProps {
   folder: FavoriteFolderUiType;
   onClick?: () => void;
-  onRenameClick?: (folderId: string) => void;
+  onRenameSubmit?: (folderId: string, newName: string) => void;
   onDeleteClick?: (folderId: string) => void;
 }
 
 const FavoriteFolderCard = ({
   folder,
   onClick,
-  onRenameClick,
+  onRenameSubmit,
   onDeleteClick,
 }: FavoriteFolderCardProps) => {
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [nameInput, setNameInput] = useState(folder.name);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const startRenaming = () => {
+    setNameInput(folder.name);
+    setIsRenaming(true);
+    setTimeout(() => inputRef.current?.select(), 0);
+  };
+
+  const submitRename = () => {
+    const trimmed = nameInput.trim();
+    if (trimmed && trimmed !== folder.name) {
+      onRenameSubmit?.(folder.id, trimmed);
+    }
+    setIsRenaming(false);
+  };
+
   return (
     <article
-      onClick={onClick}
+      onClick={isRenaming ? undefined : onClick}
       className={cn(
         'px-10 py-7 flex flex-1 items-center justify-between gap-10',
-        'rounded-10 border-2 border-gray-800 bg-gray-900 cursor-pointer'
+        'rounded-10 border-2 border-gray-800 bg-gray-900 cursor-pointer',
+        isRenaming && 'cursor-default',
       )}
     >
-      <div className='flex flex-1 items-center gap-10'>
+      <div className='flex flex-1 items-center gap-10 min-w-0'>
         <FavoriteFolderCover images={folder.coverImages} />
 
-        <div className='flex flex-col gap-2 min-w-0'>
-          <h3 className='truncate typo-24b text-gray-100'>{folder.name}</h3>
+        <div className='flex flex-col gap-2 min-w-0 flex-1'>
+          {isRenaming ? (
+            <InputField
+              ref={inputRef}
+              value={nameInput}
+              onChange={(e) => setNameInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') submitRename();
+                if (e.key === 'Escape') setIsRenaming(false);
+              }}
+              onBlur={submitRename}
+              onClick={(e) => e.stopPropagation()}
+              className='typo-24b'
+            />
+          ) : (
+            <h3 className='truncate typo-24b text-gray-100'>{folder.name}</h3>
+          )}
           <div className='flex flex-col gap-1'>
             <p className='typo-20r text-gray-400'>{folder.updatedAt}</p>
             <p className='typo-20r text-gray-400'>{folder.songCount}곡</p>
@@ -50,9 +86,7 @@ const FavoriteFolderCard = ({
             type='button'
             aria-label='폴더 메뉴 열기'
             className='shrink-0'
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
+            onClick={(e) => e.stopPropagation()}
           >
             <IcMore className='rotate-90' />
           </button>
@@ -64,11 +98,17 @@ const FavoriteFolderCard = ({
           sideOffset={12}
           alignOffset={-28}
           onClick={(e) => e.stopPropagation()}
+          onCloseAutoFocus={(e) => {
+            if (isRenaming) {
+              e.preventDefault();
+              inputRef.current?.focus();
+            }
+          }}
         >
           <DropdownMenuItem
             onClick={(e) => {
               e.stopPropagation();
-              onRenameClick?.(folder.id);
+              startRenaming();
             }}
           >
             폴더 이름 변경하기

--- a/frontend/apps/client/src/entities/library/ui/FavoriteFolderCover.tsx
+++ b/frontend/apps/client/src/entities/library/ui/FavoriteFolderCover.tsx
@@ -8,30 +8,43 @@ interface FavoriteFolderCoverProps {
   className?: string;
 }
 
+const gridConfig = {
+  0: 'grid-cols-1 grid-rows-1',
+  1: 'grid-cols-1 grid-rows-1',
+  2: 'grid-cols-2 grid-rows-1',
+  3: 'grid-cols-2 grid-rows-2',
+  4: 'grid-cols-2 grid-rows-2',
+} as const;
+
 const FavoriteFolderCover = ({ images, className }: FavoriteFolderCoverProps) => {
   const coverImages = images.slice(0, 4);
+  const count = coverImages.length;
+
+  if (count === 0) {
+    return <div className={cn('size-31.5 rounded-10 shrink-0 bg-gray-800', className)} />;
+  }
 
   return (
     <div
       className={cn(
-        'size-31.5 grid grid-cols-2 grid-rows-2 overflow-hidden rounded-10 shrink-0',
+        'size-31.5 grid overflow-hidden rounded-10 shrink-0',
+        gridConfig[count as keyof typeof gridConfig],
         className,
       )}
     >
-      {Array.from({ length: 4 }).map((_, index) => {
-        const src = coverImages[index];
-
-        return (
-          <div key={index} className='relative size-full'>
-            <AppImage
-              src={src}
-              alt={`folder-cover-${index}`}
-              fill
-              className='object-cover'
-            />
-          </div>
-        );
-      })}
+      {coverImages.map((src, index) => (
+        <div
+          key={index}
+          className={cn('relative size-full', count === 3 && index === 2 && 'col-span-2')}
+        >
+          <AppImage
+            src={src}
+            alt={`folder-cover-${index}`}
+            fill
+            className='object-cover'
+          />
+        </div>
+      ))}
     </div>
   );
 };

--- a/frontend/apps/client/src/entities/library/ui/HistoryItem.tsx
+++ b/frontend/apps/client/src/entities/library/ui/HistoryItem.tsx
@@ -44,13 +44,16 @@ const HistoryItem = ({ item, onEditClick, onDeleteClick }: HistoryItemProps) => 
           {/* 더보기 드롭다운 */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <IcMore className='rotate-90 cursor-pointer' />
+              <button type='button' aria-label='기록 메뉴 열기' className='shrink-0'>
+                <IcMore className='rotate-90' />
+              </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent
               side='bottom'
               align='end'
               sideOffset={12}
               alignOffset={-28}
+              onClick={(e) => e.stopPropagation()}
             >
               <DropdownMenuItem onSelect={() => onEditClick?.(item.historyId)}>
                 기록 수정하기

--- a/frontend/apps/client/src/features/block/model/useBlockedItems.ts
+++ b/frontend/apps/client/src/features/block/model/useBlockedItems.ts
@@ -27,7 +27,7 @@ export const useBlockedItems = (type: 'song' | 'artist') => {
     return (blockedSingerQuery.data?.blocked_singers ?? []).map((item) => ({
       id: String(item.singer_id),
       thumbnail: item.photo_url ?? undefined,
-      title: item.name,
+      title: item.name, // 가수명이 title로 들어가서 artist는 undefined로 처리
       artist: undefined as string | undefined,
     }));
   }, [type, blockedSongQuery.data, blockedSingerQuery.data]);

--- a/frontend/apps/client/src/features/block/model/useBlockedItems.ts
+++ b/frontend/apps/client/src/features/block/model/useBlockedItems.ts
@@ -1,5 +1,10 @@
 import { useMemo, useState } from 'react';
-import { useBlockedSingers, useBlockedSongs, useUnblockSinger, useUnblockSong } from '@/entities/user';
+import {
+  useBlockedSingers,
+  useBlockedSongs,
+  useUnblockSinger,
+  useUnblockSong,
+} from '@/entities/user';
 
 export const useBlockedItems = (type: 'song' | 'artist') => {
   const [query, setQuery] = useState('');
@@ -7,8 +12,8 @@ export const useBlockedItems = (type: 'song' | 'artist') => {
   const blockedSongQuery = useBlockedSongs();
   const blockedSingerQuery = useBlockedSingers();
 
-  const { mutate: unblockSong } = useUnblockSong();
-  const { mutate: unblockSinger } = useUnblockSinger();
+  const { mutate: unblockSong, isPending: isUnblockSongPending } = useUnblockSong();
+  const { mutate: unblockSinger, isPending: isUnblockSingerPending } = useUnblockSinger();
 
   const rawItems = useMemo(() => {
     if (type === 'song') {
@@ -30,9 +35,7 @@ export const useBlockedItems = (type: 'song' | 'artist') => {
   const normalizedItems = useMemo(() => {
     const q = query.trim();
     if (!q) return rawItems;
-    return rawItems.filter((item) =>
-      `${item.title} ${item.artist ?? ''}`.includes(q)
-    );
+    return rawItems.filter((item) => `${item.title} ${item.artist ?? ''}`.includes(q));
   }, [query, rawItems]);
 
   const unblock = (id: string) => {
@@ -41,7 +44,9 @@ export const useBlockedItems = (type: 'song' | 'artist') => {
   };
 
   const isLoading =
-    type === 'song' ? blockedSongQuery.isLoading : blockedSingerQuery.isLoading;
+    type === 'song'
+      ? blockedSongQuery.isLoading || isUnblockSongPending
+      : blockedSingerQuery.isLoading || isUnblockSingerPending;
 
   return { query, setQuery, normalizedItems, unblock, isLoading };
 };

--- a/frontend/apps/client/src/features/block/ui/SongBlockMenu.tsx
+++ b/frontend/apps/client/src/features/block/ui/SongBlockMenu.tsx
@@ -25,12 +25,11 @@ const SongBlockMenu = ({ songId, singerId }: SongBlockMenuProps) => {
           type='button'
           aria-label='더보기'
           className='inline-flex items-center justify-center'
-          onClick={(e) => e.stopPropagation()}
         >
           <IcMore />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align='end'>
+      <DropdownMenuContent align='end' onClick={(e) => e.stopPropagation()}>
         <DropdownMenuItem onSelect={() => blockSong({ song_id: songId })}>
           곡 차단하기
         </DropdownMenuItem>

--- a/frontend/apps/client/src/features/busking/hooks/useBuskingSocket.ts
+++ b/frontend/apps/client/src/features/busking/hooks/useBuskingSocket.ts
@@ -81,7 +81,6 @@ export const useBuskingSocket = ({
       };
 
       ws.onmessage = (e) => {
-        console.log('[WS 수신]', e.data);
         const event: BuskingSocketEvent = JSON.parse(e.data);
 
         switch (event.type) {

--- a/frontend/apps/client/src/features/busking/ui/SetlistCarousel.tsx
+++ b/frontend/apps/client/src/features/busking/ui/SetlistCarousel.tsx
@@ -56,7 +56,7 @@ const SetlistCarousel = ({
   };
 
   return (
-    <section className='relative flex h-62 flex-col items-center justify-center overflow-hidden'>
+    <section className='relative flex h-62 flex-col items-center justify-center overflow-hidden shrink-0'>
       <div className='relative w-full overflow-hidden' style={{ height: CARD_HEIGHT }}>
         <div
           className='absolute top-0 transition-transform duration-300 ease-in-out'

--- a/frontend/apps/client/src/features/like/ui/FolderSelectModal.tsx
+++ b/frontend/apps/client/src/features/like/ui/FolderSelectModal.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { BaseModal } from '@/shared/components';
+import { FavoriteFolderCover } from '@/entities/library/ui';
+import { useFolders } from '@/entities/library';
+
+type FolderSelectModalProps = {
+  onSelect: (folderId: string) => void;
+  onClose: () => void;
+};
+
+const FolderSelectModal = ({ onSelect, onClose }: FolderSelectModalProps) => {
+  const { data: folders = [] } = useFolders();
+
+  return (
+    <BaseModal
+      onClose={onClose}
+      className='relative px-10 flex flex-col w-full max-w-140 bg-bg rounded-20'
+    >
+      <div className='pt-12 pb-8 flex flex-col gap-6'>
+        <h2 className='typo-24b text-white px-4'>폴더 선택</h2>
+
+        <div className='flex flex-col max-h-120 overflow-y-auto scrollbar-hide'>
+          {folders.map((folder) => (
+            <button
+              key={folder.id}
+              type='button'
+              onClick={() => onSelect(folder.id)}
+              className='flex items-center gap-6 px-4 py-4 rounded-10 hover:bg-gray-800 transition-colors text-left'
+            >
+              <FavoriteFolderCover images={folder.coverImages} className='size-14' />
+              <div className='flex flex-col min-w-0'>
+                <span className='typo-18m text-gray-100 truncate'>{folder.name}</span>
+                <span className='typo-14r text-gray-400'>{folder.songCount}곡</span>
+              </div>
+            </button>
+          ))}
+
+          {folders.length === 0 && (
+            <p className='px-4 py-6 typo-16r text-gray-500 text-center'>
+              생성된 폴더가 없어요
+            </p>
+          )}
+        </div>
+      </div>
+    </BaseModal>
+  );
+};
+
+export default FolderSelectModal;

--- a/frontend/apps/client/src/features/like/ui/SongLikeButton.tsx
+++ b/frontend/apps/client/src/features/like/ui/SongLikeButton.tsx
@@ -1,29 +1,69 @@
 'use client';
 
+import { useModal } from '@/shared/hooks';
 import { LikeIconButton } from '@/entities/song/ui';
-import { useWishlist, useDeleteWishlistItem } from '@/entities/library';
+import type { SongUiType } from '@/entities/song';
+import {
+  useWishlist,
+  useDeleteWishlistItem,
+  useAddWishlistItem,
+} from '@/entities/library';
+import FolderSelectModal from './FolderSelectModal';
 
 type SongLikeButtonProps = {
   isLiked: boolean;
   songId: string;
   folderId?: string;
+  song?: Pick<SongUiType, 'title' | 'artist' | 'thumbnail'>;
 };
 
-const SongLikeButton = ({ isLiked, songId, folderId }: SongLikeButtonProps) => {
+const SongLikeButton = ({ isLiked, songId, folderId, song }: SongLikeButtonProps) => {
   const { data: wishlist = [] } = useWishlist(folderId);
   const { mutate: deleteWishlistItem } = useDeleteWishlistItem();
+  const { mutate: addWishlistItem } = useAddWishlistItem();
+  const folderModal = useModal();
+
+  const addToFolder = (selectedFolderId?: string) => {
+    addWishlistItem({
+      song_data: {
+        name: song?.title ?? '',
+        artist: song?.artist ?? '',
+        album_image: song?.thumbnail ?? null,
+        uri: songId,
+      } as unknown as Record<string, never>,
+      folder_id: selectedFolderId,
+    });
+  };
 
   const handleClick = () => {
     if (isLiked && folderId) {
       const item = wishlist.find((w) => w.songId === songId);
       if (item) deleteWishlistItem(item.itemId);
-    } else {
-      // TODO: 찜하기 API 연결
-      console.log('like', songId);
+    } else if (!isLiked) {
+      if (folderId) {
+        addToFolder(folderId);
+      } else {
+        folderModal.openModal();
+      }
     }
   };
 
-  return <LikeIconButton isLiked={isLiked} onClick={handleClick} />;
+  const handleFolderSelect = (selectedFolderId: string) => {
+    addToFolder(selectedFolderId);
+    folderModal.closeModal();
+  };
+
+  return (
+    <>
+      <LikeIconButton isLiked={isLiked} onClick={handleClick} />
+      {folderModal.open && (
+        <FolderSelectModal
+          onSelect={handleFolderSelect}
+          onClose={folderModal.closeModal}
+        />
+      )}
+    </>
+  );
 };
 
 export default SongLikeButton;

--- a/frontend/apps/client/src/shared/hooks/useClickOutside.ts
+++ b/frontend/apps/client/src/shared/hooks/useClickOutside.ts
@@ -1,7 +1,13 @@
 import { useEffect, RefObject } from 'react';
 
-const useClickOutside = (ref: RefObject<HTMLElement | null>, callback: () => void) => {
+const useClickOutside = (
+  ref: RefObject<HTMLElement | null>,
+  callback: () => void,
+  enabled = true,
+) => {
   useEffect(() => {
+    if (!enabled) return;
+
     const handleClick = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         callback();
@@ -10,7 +16,7 @@ const useClickOutside = (ref: RefObject<HTMLElement | null>, callback: () => voi
 
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
-  }, [ref, callback]);
+  }, [ref, callback, enabled]);
 };
 
 export default useClickOutside;

--- a/frontend/apps/client/src/widgets/archive/ui/ArchiveListWidget.tsx
+++ b/frontend/apps/client/src/widgets/archive/ui/ArchiveListWidget.tsx
@@ -24,7 +24,7 @@ const ArchiveListWidget = ({
   const { open: isOpen, openModal, closeModal } = useModal();
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  useClickOutside(wrapperRef, closeModal);
+  useClickOutside(wrapperRef, closeModal, isOpen);
 
   return (
     <section className='px-8 py-6 flex flex-col gap-4'>

--- a/frontend/apps/client/src/widgets/library/ui/LibraryFavoriteList.tsx
+++ b/frontend/apps/client/src/widgets/library/ui/LibraryFavoriteList.tsx
@@ -8,7 +8,7 @@ import { FavoriteFolderCard } from '@/entities/library/ui';
 import type { FavoriteFolderUiType } from '@/entities/library/model/types';
 import FavoriteFolderDetail from './FavoriteFolderDetail';
 
-import { useFolders, useDeleteFolder } from '@/entities/library';
+import { useFolders, useDeleteFolder, useRenameFolder } from '@/entities/library';
 
 const LibraryFavoriteList = () => {
   const { open: isAddModalOpen, openModal, closeModal } = useModal(false);
@@ -16,6 +16,7 @@ const LibraryFavoriteList = () => {
 
   const { data: folders = [] } = useFolders();
   const { mutate: deleteFolder } = useDeleteFolder();
+  const { mutate: renameFolder } = useRenameFolder();
 
   if (selectedFolder) {
     return (
@@ -40,7 +41,9 @@ const LibraryFavoriteList = () => {
             <FavoriteFolderCard
               folder={folder}
               onClick={() => setSelectedFolder(folder)}
-              onRenameClick={() => {}} // TODO: 폴더 이름 변경 기능 논의 필요
+              onRenameSubmit={(folderId, newName) =>
+                renameFolder({ folderId, body: { name: newName } })
+              }
               onDeleteClick={() => deleteFolder(folder.id)}
             />
           </li>

--- a/frontend/packages/api/src/schema.d.ts
+++ b/frontend/packages/api/src/schema.d.ts
@@ -284,7 +284,8 @@ export interface paths {
         delete: operations["delete_folder_api_v1_library_folders__folder_id__delete"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** Rename Folder */
+        patch: operations["rename_folder_api_v1_library_folders__folder_id__patch"];
         trace?: never;
     };
     "/api/v1/library/wishlist": {
@@ -1376,6 +1377,16 @@ export interface components {
              * @default 0
              */
             item_count: number;
+            /**
+             * Thumbnails
+             * @default []
+             */
+            thumbnails: string[];
+        };
+        /** FolderUpdate */
+        FolderUpdate: {
+            /** Name */
+            name: string;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -2372,6 +2383,41 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rename_folder_api_v1_library_folders__folder_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                folder_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FolderUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FolderResponse"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/frontend/packages/tailwind-config/styles/base.css
+++ b/frontend/packages/tailwind-config/styles/base.css
@@ -1,9 +1,13 @@
 @layer base {
-  html,
-  body {
+  html {
     height: 100%;
     max-width: 100vw;
     overflow-x: hidden;
+    overscroll-behavior: none;
+  }
+
+  body {
+    height: 100%;
     overscroll-behavior: none;
   }
 


### PR DESCRIPTION
<!-- PR의 제목은 "Feat(scope): summary" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #230


## 📤 Tasks
<!-- 해당 PR에 대한 작업 내용을 작성해주세요. -->

- 폴더 썸네일 그리드 UI를 구현했습니다.

- 폴더 이름 변경 기능을 구현했습니다.
  - 폴더 카드의 드롭다운에서 이름 변경을 선택하면 인라인 입력 상태로 전환되도록 구현했습니다.
  - Enter 입력 또는 blur 시 -> 변경 내용 제출, Escape 입력 시 변경 취소 처리

- 찜하기 API를 연결했습니다.
  - 찜 추가 시 폴더를 지정해야 한다는 플로우가 누락되면서 구현이 지연됐던 기능인데, 폴더 선택 모달을 추가해 해결했습니다.

- 찜 추가/삭제 기능에 낙관적 업데이트를 적용했습니다.
  - 찜 추가 시 임시 아이템을 먼저 캐시에 반영해 UI가 즉시 갱신되도록 처리했습니다.
  - 찜 삭제 시 관련 wishlist 캐시에서 해당 아이템을 먼저 제거하도록 처리했습니다.
  - 요청 실패 시 이전 캐시 상태로 롤백되도록 처리했습니다.
  - 찜 추가/삭제 이후 폴더 목록 쿼리를 무효화해 폴더의 곡 개수와 썸네일 정보가 갱신되도록 처리했습니다.

- 버스킹 라이브 화면 동작을 보완했습니다.
  - 라이브 룸에서 뒤로가기 시 이전 페이지가 아닌 버스킹 목록으로 이동하도록 수정했습니다.
  - 시청자 화면에서 투표 패널이 항상 노출되도록 조건을 정리했습니다.
  - 셋리스트 캐러셀이 화면에서 잘리지 않도록 `shrink-0` 스타일을 추가했습니다.

- 차단 해제 및 드롭다운 UI를 개선했습니다.
  - 차단 해제 요청 중에는 로딩 상태에 포함되도록 처리해 중복 액션을 방지했습니다.
  - 드롭다운 클릭 시 상위 카드 클릭 이벤트와 충돌하지 않도록 이벤트 전파를 막았습니다.
  - 기록/차단 메뉴의 드롭다운이 보이지 않던 문제를 수정했습니다.

- `useClickOutside` 훅을 개선했습니다.
  - 외부 클릭 감지 동작을 필요한 경우에만 활성화할 수 있도록 `enabled` 옵션을 추가했습니다.
  - 아카이브 목록 위젯에서 모달이 열려 있을 때만 외부 클릭 감지가 동작하도록 수정했습니다.

- 전역 스타일을 일부 정리했습니다.
  - `html`과 `body` 스타일을 분리해 height, overflow, overscroll 동작을 명확히 설정했습니다.
 
<br/>

## 📸 Screenshot
<!-- 관련 스크린샷을 첨부해주세요. -->

<br/>

## 💌 To Reviewer
<!-- 리뷰어가 집중해주면 좋을 부분/논의할 부분이 있다면 작성해주세요. -->
변경된 라이브 결과 응답 데이터를 반영하려 했으나, 해당 API에서 **500 에러**가 뜬다는 점 알려드립니다!
또한, 아직 **녹음 업로드 관련 API**가 구현되지 않은 상태인 것 같아 확인하시는대로 구현 부탁드립니다.
마지막으로, **Presigned URL로 이미지 업로드 시 CORS 오류**에 대한 대응을 백엔드에서 해주신 것 같은데,
아직도 에러가 떠서 S3에서 권한 확인이 필요해보입니다!

항상 감사해요 🙇‍♀️

<br/>
