### PR TITLE
Feat(server): 녹음 버스킹 api구현

### DIFF
--- a/backend/app/models/recorded_busking.py
+++ b/backend/app/models/recorded_busking.py
@@ -1,0 +1,43 @@
+"""녹음 버스킹 모델"""
+import uuid
+from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Uuid, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class RecordedBusking(Base):
+    __tablename__ = "recorded_buskings"
+
+    id = Column(Uuid, primary_key=True, default=uuid.uuid4)
+    host_id = Column(Uuid, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    title = Column(String(200), nullable=False)
+    thumbnail = Column(String(500), nullable=True)
+    recording_url = Column(String(500), nullable=False)
+    s3_key = Column(String(500), nullable=False)
+    song_data = Column(JSONB, nullable=False)  # { name, artist, album_image, uri }
+    vote_ends_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class RecordedBuskingComment(Base):
+    __tablename__ = "recorded_busking_comments"
+
+    id = Column(Uuid, primary_key=True, default=uuid.uuid4)
+    busking_id = Column(Uuid, ForeignKey("recorded_buskings.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id = Column(Uuid, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    content = Column(Text, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class RecordedBuskingReaction(Base):
+    __tablename__ = "recorded_busking_reactions"
+
+    id = Column(Uuid, primary_key=True, default=uuid.uuid4)
+    busking_id = Column(Uuid, ForeignKey("recorded_buskings.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id = Column(Uuid, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    value = Column(String(10), nullable=False)  # 'match' | 'mismatch'
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (UniqueConstraint("busking_id", "user_id", name="uq_rec_busking_reaction_user"),)

--- a/backend/app/routers/home.py
+++ b/backend/app/routers/home.py
@@ -12,8 +12,10 @@ from app.database import get_db
 from app.dependencies.auth import get_current_user, get_optional_user
 from app.models.busking import BuskingRoom
 from app.models.library import WishlistItem
+from app.models.recorded_busking import RecordedBusking, RecordedBuskingReaction
 from app.models.user import User
 from app.routers.busking import manager as busking_manager
+from app.schemas.recorded_busking import RecordedBuskingPreview, VoteRemaining
 
 router = APIRouter(prefix="/api/v1", tags=["Home"])
 
@@ -37,6 +39,7 @@ class LiveTickerItem(BaseModel):
 class HomeFeedsResponse(BaseModel):
     weekly: List[WeeklySong]
     live_ticker: List[LiveTickerItem]
+    recorded_buskings: List[RecordedBuskingPreview] = []
 
 
 # ── GET /api/v1/home/feeds ────────────────────────────
@@ -52,7 +55,8 @@ async def get_home_feeds(
 
     weekly = await _get_weekly_chart(db, liked_uris)
     live_ticker = await _get_live_ticker(db)
-    return HomeFeedsResponse(weekly=weekly, live_ticker=live_ticker)
+    recorded_buskings = await _get_recorded_buskings(db)
+    return HomeFeedsResponse(weekly=weekly, live_ticker=live_ticker, recorded_buskings=recorded_buskings)
 
 
 # ── GET /api/v1/busking/live-ticker ──────────────────
@@ -105,6 +109,73 @@ async def _get_weekly_chart(db: AsyncSession, liked_uris: Optional[set] = None) 
         )
         for i, (key, count) in enumerate(top5)
     ]
+
+
+async def _get_recorded_buskings(db: AsyncSession, limit: int = 10) -> List[RecordedBuskingPreview]:
+    from sqlalchemy import func
+    items = (await db.execute(
+        select(RecordedBusking)
+        .order_by(RecordedBusking.created_at.desc())
+        .limit(limit)
+    )).scalars().all()
+    if not items:
+        return []
+
+    busking_ids = [i.id for i in items]
+    host_ids = list({i.host_id for i in items})
+
+    hosts = {
+        u.id: u for u in (await db.execute(
+            select(User).where(User.id.in_(host_ids))
+        )).scalars().all()
+    }
+
+    reaction_rows = (await db.execute(
+        select(
+            RecordedBuskingReaction.busking_id,
+            RecordedBuskingReaction.value,
+            func.count().label("cnt"),
+        )
+        .where(RecordedBuskingReaction.busking_id.in_(busking_ids))
+        .group_by(RecordedBuskingReaction.busking_id, RecordedBuskingReaction.value)
+    )).all()
+    match_map: dict = {}
+    mismatch_map: dict = {}
+    for row in reaction_rows:
+        if row.value == "match":
+            match_map[row.busking_id] = row.cnt
+        else:
+            mismatch_map[row.busking_id] = row.cnt
+
+    now = datetime.now(timezone.utc)
+
+    def _remaining(vote_ends_at) -> VoteRemaining:
+        if vote_ends_at.tzinfo is None:
+            vote_ends_at = vote_ends_at.replace(tzinfo=timezone.utc)
+        delta = vote_ends_at - now
+        if delta.total_seconds() <= 0:
+            return VoteRemaining(days=0, hours=0, minutes=0, is_ended=True)
+        total = int(delta.total_seconds())
+        return VoteRemaining(days=total // 86400, hours=(total % 86400) // 3600, minutes=(total % 3600) // 60, is_ended=False)
+
+    result = []
+    for item in items:
+        host = hosts.get(item.host_id)
+        if not host:
+            continue
+        result.append(RecordedBuskingPreview(
+            id=item.id,
+            host_nickname=host.nickname,
+            host_profile_img=host.profile_img,
+            title=item.title,
+            thumbnail=item.thumbnail,
+            song_data=item.song_data,
+            vote_remaining=_remaining(item.vote_ends_at),
+            match_count=match_map.get(item.id, 0),
+            mismatch_count=mismatch_map.get(item.id, 0),
+            created_at=item.created_at,
+        ))
+    return result
 
 
 async def _get_live_ticker(db: AsyncSession) -> List[LiveTickerItem]:

--- a/backend/app/routers/library.py
+++ b/backend/app/routers/library.py
@@ -20,7 +20,9 @@ from app.schemas.library import (
     FolderCreate, FolderUpdate, FolderResponse,
     WishlistItemCreate, WishlistItemResponse,
 )
-from app.schemas.archive import ArchiveCreate, ArchiveUpdate, ArchiveResponse
+from app.schemas.archive import ArchiveCreate, ArchiveUpdate, ArchiveResponse, RecordingUploadUrlResponse
+from app.utils.aws import generate_presigned_url
+from app.config import settings
 
 router = APIRouter(prefix="/api/v1/library", tags=["Library"])
 

--- a/backend/app/routers/recorded_busking.py
+++ b/backend/app/routers/recorded_busking.py
@@ -1,0 +1,357 @@
+"""녹음 버스킹 라우터"""
+import uuid as uuid_lib
+from datetime import datetime, timezone
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import get_db
+from app.dependencies.auth import get_current_user, get_optional_user
+from app.models.recorded_busking import RecordedBusking, RecordedBuskingComment, RecordedBuskingReaction
+from app.models.user import User
+from app.schemas.recorded_busking import (
+    CommentCreate, CommentResponse,
+    HostProfile, ReactionRequest,
+    RecordedBuskingCreate, RecordedBuskingPreview, RecordedBuskingResponse,
+    RecordingUploadUrlResponse, VoteRemaining,
+)
+from app.utils.aws import generate_presigned_url
+
+router = APIRouter(prefix="/api/v1/busking/recordings", tags=["RecordedBusking"])
+
+
+# ── 유틸 ──────────────────────────────────────────────────────
+
+def _vote_remaining(vote_ends_at: datetime) -> VoteRemaining:
+    now = datetime.now(timezone.utc)
+    if vote_ends_at.tzinfo is None:
+        vote_ends_at = vote_ends_at.replace(tzinfo=timezone.utc)
+    delta = vote_ends_at - now
+    if delta.total_seconds() <= 0:
+        return VoteRemaining(days=0, hours=0, minutes=0, is_ended=True)
+    total = int(delta.total_seconds())
+    return VoteRemaining(
+        days=total // 86400,
+        hours=(total % 86400) // 3600,
+        minutes=(total % 3600) // 60,
+        is_ended=False,
+    )
+
+
+async def _fetch_counts(db: AsyncSession, busking_ids: list):
+    """busking_ids 전체의 match/mismatch/comment 수를 한 번에 집계."""
+    reaction_rows = (await db.execute(
+        select(
+            RecordedBuskingReaction.busking_id,
+            RecordedBuskingReaction.value,
+            func.count().label("cnt"),
+        )
+        .where(RecordedBuskingReaction.busking_id.in_(busking_ids))
+        .group_by(RecordedBuskingReaction.busking_id, RecordedBuskingReaction.value)
+    )).all()
+
+    match_map: dict = {}
+    mismatch_map: dict = {}
+    for row in reaction_rows:
+        if row.value == "match":
+            match_map[row.busking_id] = row.cnt
+        else:
+            mismatch_map[row.busking_id] = row.cnt
+
+    comment_rows = (await db.execute(
+        select(RecordedBuskingComment.busking_id, func.count().label("cnt"))
+        .where(RecordedBuskingComment.busking_id.in_(busking_ids))
+        .group_by(RecordedBuskingComment.busking_id)
+    )).all()
+    comment_map = {r.busking_id: r.cnt for r in comment_rows}
+
+    return match_map, mismatch_map, comment_map
+
+
+# ── 1. 녹음 파일 presigned URL 발급 ───────────────────────────
+
+@router.post("/upload-url", response_model=RecordingUploadUrlResponse)
+async def get_recording_upload_url(
+    current_user: User = Depends(get_current_user),
+):
+    s3_key = f"busking/recordings/{current_user.id}/{uuid_lib.uuid4()}.m4a"
+    upload_url = generate_presigned_url(s3_key, content_type="audio/m4a")
+    if not upload_url:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={"code": "S3_URL_FAILED", "message": "업로드 URL 생성에 실패했습니다."},
+        )
+    public_url = f"https://{settings.S3_BUCKET_NAME}.s3.{settings.AWS_REGION}.amazonaws.com/{s3_key}"
+    return RecordingUploadUrlResponse(upload_url=upload_url, s3_key=s3_key, public_url=public_url)
+
+
+# ── 2. 녹음 버스킹 생성 ───────────────────────────────────────
+
+@router.post("", response_model=RecordedBuskingResponse, status_code=status.HTTP_201_CREATED)
+async def create_recorded_busking(
+    body: RecordedBuskingCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    public_url = f"https://{settings.S3_BUCKET_NAME}.s3.{settings.AWS_REGION}.amazonaws.com/{body.s3_key}"
+    item = RecordedBusking(
+        host_id=current_user.id,
+        title=body.title,
+        thumbnail=body.thumbnail_url,
+        recording_url=public_url,
+        s3_key=body.s3_key,
+        song_data=body.song_data,
+        vote_ends_at=body.vote_ends_at,
+    )
+    db.add(item)
+    await db.flush()
+    await db.refresh(item)
+
+    return RecordedBuskingResponse(
+        id=item.id,
+        host_profile=HostProfile(id=current_user.id, nickname=current_user.nickname, profile_img=current_user.profile_img),
+        title=item.title,
+        thumbnail=item.thumbnail,
+        recording_url=item.recording_url,
+        song_data=item.song_data,
+        vote_ends_at=item.vote_ends_at,
+        vote_remaining=_vote_remaining(item.vote_ends_at),
+        match_count=0,
+        mismatch_count=0,
+        comment_count=0,
+        my_reaction=None,
+        created_at=item.created_at,
+    )
+
+
+# ── 3. 목록 조회 ──────────────────────────────────────────────
+
+@router.get("", response_model=List[RecordedBuskingResponse])
+async def list_recorded_buskings(
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    current_user: Optional[User] = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+):
+    items = (await db.execute(
+        select(RecordedBusking)
+        .order_by(RecordedBusking.created_at.desc())
+        .offset((page - 1) * size)
+        .limit(size)
+    )).scalars().all()
+
+    if not items:
+        return []
+
+    busking_ids = [i.id for i in items]
+
+    hosts = {
+        u.id: u for u in (await db.execute(
+            select(User).where(User.id.in_([i.host_id for i in items]))
+        )).scalars().all()
+    }
+
+    match_map, mismatch_map, comment_map = await _fetch_counts(db, busking_ids)
+
+    my_reaction_map: dict = {}
+    if current_user:
+        rows = (await db.execute(
+            select(RecordedBuskingReaction.busking_id, RecordedBuskingReaction.value)
+            .where(
+                RecordedBuskingReaction.busking_id.in_(busking_ids),
+                RecordedBuskingReaction.user_id == current_user.id,
+            )
+        )).all()
+        my_reaction_map = {r.busking_id: r.value for r in rows}
+
+    result = []
+    for item in items:
+        host = hosts.get(item.host_id)
+        if not host:
+            continue
+        result.append(RecordedBuskingResponse(
+            id=item.id,
+            host_profile=HostProfile(id=host.id, nickname=host.nickname, profile_img=host.profile_img),
+            title=item.title,
+            thumbnail=item.thumbnail,
+            recording_url=item.recording_url,
+            song_data=item.song_data,
+            vote_ends_at=item.vote_ends_at,
+            vote_remaining=_vote_remaining(item.vote_ends_at),
+            match_count=match_map.get(item.id, 0),
+            mismatch_count=mismatch_map.get(item.id, 0),
+            comment_count=comment_map.get(item.id, 0),
+            my_reaction=my_reaction_map.get(item.id),
+            created_at=item.created_at,
+        ))
+    return result
+
+
+# ── 4. 단건 조회 ──────────────────────────────────────────────
+
+@router.get("/{busking_id}", response_model=RecordedBuskingResponse)
+async def get_recorded_busking(
+    busking_id: UUID,
+    current_user: Optional[User] = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+):
+    item = (await db.execute(
+        select(RecordedBusking).where(RecordedBusking.id == busking_id)
+    )).scalar_one_or_none()
+    if not item:
+        raise HTTPException(status_code=404, detail={"code": "NOT_FOUND", "message": "녹음 버스킹을 찾을 수 없습니다."})
+
+    host = (await db.execute(select(User).where(User.id == item.host_id))).scalar_one_or_none()
+    if not host:
+        raise HTTPException(status_code=404, detail={"code": "NOT_FOUND", "message": "호스트 정보를 찾을 수 없습니다."})
+
+    match_map, mismatch_map, comment_map = await _fetch_counts(db, [busking_id])
+
+    my_reaction = None
+    if current_user:
+        my_reaction = (await db.execute(
+            select(RecordedBuskingReaction.value).where(
+                RecordedBuskingReaction.busking_id == busking_id,
+                RecordedBuskingReaction.user_id == current_user.id,
+            )
+        )).scalar_one_or_none()
+
+    return RecordedBuskingResponse(
+        id=item.id,
+        host_profile=HostProfile(id=host.id, nickname=host.nickname, profile_img=host.profile_img),
+        title=item.title,
+        thumbnail=item.thumbnail,
+        recording_url=item.recording_url,
+        song_data=item.song_data,
+        vote_ends_at=item.vote_ends_at,
+        vote_remaining=_vote_remaining(item.vote_ends_at),
+        match_count=match_map.get(busking_id, 0),
+        mismatch_count=mismatch_map.get(busking_id, 0),
+        comment_count=comment_map.get(busking_id, 0),
+        my_reaction=my_reaction,
+        created_at=item.created_at,
+    )
+
+
+# ── 5. 투표 (어울려요 / 안어울려요) ──────────────────────────
+
+@router.post("/{busking_id}/reactions", status_code=status.HTTP_204_NO_CONTENT)
+async def react(
+    busking_id: UUID,
+    body: ReactionRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    if body.value not in ("match", "mismatch"):
+        raise HTTPException(status_code=400, detail={"code": "INVALID_VALUE", "message": "value는 match 또는 mismatch여야 합니다."})
+
+    item = (await db.execute(
+        select(RecordedBusking.vote_ends_at).where(RecordedBusking.id == busking_id)
+    )).scalar_one_or_none()
+    if not item:
+        raise HTTPException(status_code=404, detail={"code": "NOT_FOUND", "message": "녹음 버스킹을 찾을 수 없습니다."})
+    if _vote_remaining(item).is_ended:
+        raise HTTPException(status_code=400, detail={"code": "VOTE_ENDED", "message": "투표가 종료되었습니다."})
+
+    existing = (await db.execute(
+        select(RecordedBuskingReaction).where(
+            RecordedBuskingReaction.busking_id == busking_id,
+            RecordedBuskingReaction.user_id == current_user.id,
+        )
+    )).scalar_one_or_none()
+
+    if existing:
+        existing.value = body.value
+    else:
+        db.add(RecordedBuskingReaction(busking_id=busking_id, user_id=current_user.id, value=body.value))
+
+
+@router.delete("/{busking_id}/reactions", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_reaction(
+    busking_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    reaction = (await db.execute(
+        select(RecordedBuskingReaction).where(
+            RecordedBuskingReaction.busking_id == busking_id,
+            RecordedBuskingReaction.user_id == current_user.id,
+        )
+    )).scalar_one_or_none()
+    if reaction:
+        await db.delete(reaction)
+
+
+# ── 6. 댓글 ──────────────────────────────────────────────────
+
+@router.get("/{busking_id}/comments", response_model=List[CommentResponse])
+async def get_comments(
+    busking_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    rows = (await db.execute(
+        select(RecordedBuskingComment, User)
+        .join(User, User.id == RecordedBuskingComment.user_id)
+        .where(RecordedBuskingComment.busking_id == busking_id)
+        .order_by(RecordedBuskingComment.created_at.asc())
+    )).all()
+    return [
+        CommentResponse(
+            id=c.id,
+            user_id=c.user_id,
+            nickname=u.nickname,
+            profile_img=u.profile_img,
+            content=c.content,
+            created_at=c.created_at,
+        )
+        for c, u in rows
+    ]
+
+
+@router.post("/{busking_id}/comments", response_model=CommentResponse, status_code=status.HTTP_201_CREATED)
+async def add_comment(
+    busking_id: UUID,
+    body: CommentCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    if not (await db.execute(
+        select(RecordedBusking.id).where(RecordedBusking.id == busking_id)
+    )).scalar_one_or_none():
+        raise HTTPException(status_code=404, detail={"code": "NOT_FOUND", "message": "녹음 버스킹을 찾을 수 없습니다."})
+
+    comment = RecordedBuskingComment(busking_id=busking_id, user_id=current_user.id, content=body.content)
+    db.add(comment)
+    await db.flush()
+    await db.refresh(comment)
+    return CommentResponse(
+        id=comment.id,
+        user_id=comment.user_id,
+        nickname=current_user.nickname,
+        profile_img=current_user.profile_img,
+        content=comment.content,
+        created_at=comment.created_at,
+    )
+
+
+@router.delete("/{busking_id}/comments/{comment_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_comment(
+    busking_id: UUID,
+    comment_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    comment = (await db.execute(
+        select(RecordedBuskingComment).where(
+            RecordedBuskingComment.id == comment_id,
+            RecordedBuskingComment.busking_id == busking_id,
+            RecordedBuskingComment.user_id == current_user.id,
+        )
+    )).scalar_one_or_none()
+    if not comment:
+        raise HTTPException(status_code=404, detail={"code": "NOT_FOUND", "message": "댓글을 찾을 수 없습니다."})
+    await db.delete(comment)

--- a/backend/app/schemas/recorded_busking.py
+++ b/backend/app/schemas/recorded_busking.py
@@ -1,0 +1,79 @@
+"""녹음 버스킹 스키마"""
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+from datetime import datetime
+
+
+class RecordingUploadUrlResponse(BaseModel):
+    upload_url: str
+    s3_key: str
+    public_url: str
+
+
+class RecordedBuskingCreate(BaseModel):
+    title: str
+    thumbnail_url: Optional[str] = None
+    s3_key: str                     # upload-url 엔드포인트에서 받은 키
+    song_data: Dict[str, Any]       # { name, artist, album_image, uri }
+    vote_ends_at: datetime          # 투표 종료 시각 (ISO8601)
+
+
+class HostProfile(BaseModel):
+    id: UUID
+    nickname: str
+    profile_img: Optional[str] = None
+
+
+class VoteRemaining(BaseModel):
+    days: int
+    hours: int
+    minutes: int
+    is_ended: bool
+
+
+class RecordedBuskingResponse(BaseModel):
+    id: UUID
+    host_profile: HostProfile
+    title: str
+    thumbnail: Optional[str] = None
+    recording_url: str
+    song_data: Dict[str, Any]
+    vote_ends_at: datetime
+    vote_remaining: VoteRemaining
+    match_count: int
+    mismatch_count: int
+    comment_count: int
+    my_reaction: Optional[str] = None   # 'match' | 'mismatch' | None
+    created_at: datetime
+
+
+class RecordedBuskingPreview(BaseModel):
+    """홈 화면 용 경량 응답"""
+    id: UUID
+    host_nickname: str
+    host_profile_img: Optional[str] = None
+    title: str
+    thumbnail: Optional[str] = None
+    song_data: Dict[str, Any]
+    vote_remaining: VoteRemaining
+    match_count: int
+    mismatch_count: int
+    created_at: datetime
+
+
+class CommentCreate(BaseModel):
+    content: str
+
+
+class CommentResponse(BaseModel):
+    id: UUID
+    user_id: UUID
+    nickname: str
+    profile_img: Optional[str] = None
+    content: str
+    created_at: datetime
+
+
+class ReactionRequest(BaseModel):
+    value: str  # 'match' | 'mismatch'

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from app.routers.home import router as home_router
 from app.routers.oauth_test import router as oauth_test_router
 from app.routers.onboarding import router as onboarding_router
 from app.routers.artist_actions import router as artist_actions_router
+from app.routers.recorded_busking import router as recorded_busking_router
 from fastapi.staticfiles import StaticFiles
 
 
@@ -50,6 +51,7 @@ app.include_router(home_router)
 app.include_router(onboarding_router)
 app.include_router(oauth_test_router)
 app.include_router(artist_actions_router)
+app.include_router(recorded_busking_router)
 
 @app.get("/health", status_code=status.HTTP_200_OK)
 async def health_check():


### PR DESCRIPTION
## 📌 Related Issue
* Closed #239 

## 📤 Tasks
- **녹음파일 업로드 URL 발급**
  - `POST /api/v1/busking/recordings/upload-url`
  - 프론트에서 S3 PUT 업로드 가능한 presigned URL 발급

- **녹음 버스킹 생성/조회**
  - `POST /api/v1/busking/recordings`
    - `s3_key`, `song_data`, `vote_ends_at` 기반 녹음 버스킹 생성
  - `GET /api/v1/busking/recordings?page=1&size=20`
    - 녹음 버스킹 목록 조회
  - `GET /api/v1/busking/recordings/{id}`
    - 녹음 버스킹 단건 조회

- **투표 기능**
  - `POST /api/v1/busking/recordings/{id}/reactions`
    - match/mismatch 투표
  - `DELETE /api/v1/busking/recordings/{id}/reactions`
    - 내 투표 취소

- **댓글 기능**
  - `GET /api/v1/busking/recordings/{id}/comments`
    - 댓글 목록 조회
  - `POST /api/v1/busking/recordings/{id}/comments`
    - 댓글 작성
  - `DELETE /api/v1/busking/recordings/{id}/comments/{comment_id}`
    - 댓글 삭제

- **홈 피드 연동**
  - `GET /api/v1/home/feeds`
    - 최신 녹음 버스킹 10개를 `recorded_buskings` 배열로 추가
    - 투표 잔여시간 포함

## 📸 Screenshot
<br/>

## 💌 To Reviewer
- S3 업로드 URL 발급 → 프론트 PUT 업로드 → 녹음 버스킹 생성 흐름 확인 부탁드립니다.
- 홈 피드의 `recorded_buskings` 응답과 투표 잔여시간 계산 확인 부탁드립니다.