### PR TITLE
Fix(server): 위시리스트 중복 찜 방지 로직 추가

### DIFF
--- a/backend/app/models/library.py
+++ b/backend/app/models/library.py
@@ -1,6 +1,6 @@
 """Library 모델 - Folder & WishlistItem"""
 import uuid
-from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, Uuid
+from sqlalchemy import Column, Index, String, Boolean, DateTime, ForeignKey, Uuid, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
@@ -31,3 +31,8 @@ class WishlistItem(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     folder = relationship("Folder", back_populates="items")
+
+    __table_args__ = (
+        # 유저당 동일 Spotify URI 중복 찜 방지
+        Index("uq_wishlist_user_uri", "user_id", text("(song_data->>'uri')"), unique=True),
+    )

--- a/backend/app/routers/library.py
+++ b/backend/app/routers/library.py
@@ -166,12 +166,25 @@ async def add_wishlist_item(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Spotify 검색 결과를 찜 목록에 추가. song_data = { name, artist, album_image, uri }"""
+    """Spotify 검색 결과를 찜 목록에 추가. song_data = { name, artist, album_image, uri }
+    동일 URI가 이미 찜 목록에 있으면 기존 항목을 그대로 반환합니다.
+    """
     if body.folder_id is not None:
         if not (await db.execute(
             select(Folder.id).where(Folder.id == body.folder_id, Folder.user_id == current_user.id)
         )).scalar_one_or_none():
             raise HTTPException(status_code=404, detail="폴더를 찾을 수 없습니다.")
+
+    uri = body.song_data.get("uri")
+    if uri:
+        existing = (await db.execute(
+            select(WishlistItem).where(
+                WishlistItem.user_id == current_user.id,
+                WishlistItem.song_data["uri"].astext == uri,
+            )
+        )).scalar_one_or_none()
+        if existing:
+            return existing
 
     item = WishlistItem(
         user_id=current_user.id,


### PR DESCRIPTION
## 📌 Related Issue

- Closes #243 


## 📤 Tasks

- 위시리스트 중복 찜 방지 로직 추가

- 중복 체크 로직 구현
  - `song_data->>'uri'` 기준으로 기존 찜 여부 확인
  - 이미 찜한 곡이면 기존 항목 반환하도록 수정

- DB 레벨 유니크 제약 추가
  - `(user_id, song_data->>'uri')` 기준 unique index 추가

- 중복 데이터 대응
  - 기존 중복 데이터 제거 SQL 추가


<br/>

## 📸 Screenshot

<!-- 필요 시 첨부 -->


<br/>

## 💌 To Reviewer

- Spotify URI 기준으로 동일 곡 여부를 판단하도록 변경했습니다.
- 기존 중복 데이터가 존재할 경우 인덱스 생성 전에 제거가 필요합니다.