### PR TITLE
Fix(server): RecordingUploadUrlResponse 임포트 오류 수정

### DIFF
--- a/backend/app/routers/library.py
+++ b/backend/app/routers/library.py
@@ -20,7 +20,7 @@ from app.schemas.library import (
     FolderCreate, FolderUpdate, FolderResponse,
     WishlistItemCreate, WishlistItemResponse,
 )
-from app.schemas.archive import ArchiveCreate, ArchiveUpdate, ArchiveResponse, RecordingUploadUrlResponse
+from app.schemas.archive import ArchiveCreate, ArchiveUpdate, ArchiveResponse
 from app.utils.aws import generate_presigned_url
 from app.config import settings
 


### PR DESCRIPTION
## 📌 Related Issue

- Closes #245 


## 📤 Tasks

- [ ] `RecordingUploadUrlResponse` 정의 위치 확인
- [ ] 잘못된 schema import 경로 수정
- [ ] 필요한 경우 presigned URL 응답용 schema 추가
- [ ] 배포 환경에서 FastAPI 앱 import 실패하지 않도록 수정
- [ ] 로컬 서버 실행으로 정상 구동 확인

<br/>

## 📸 Screenshot


<br/>

## 💌 To Reviewer

Render 배포 시 `RecordingUploadUrlResponse` import 실패로 서버가 시작되지 않는 문제가 있었습니다.

`app/routers/library.py`에서 참조하는 schema가 실제 정의 위치와 일치하는지,  
그리고 배포 환경에서도 import 에러 없이 앱이 정상 실행되는지 위주로 확인 부탁드립니다.

<br/>