### PR TITLE
Feat(server): 보컬프로필 설명 추가

### DIFF
--- a/backend/app/routers/analysis.py
+++ b/backend/app/routers/analysis.py
@@ -126,6 +126,7 @@ async def get_vocal_profile(
     genre_fit = None
     timbre = None
     range_info = None
+    descriptions = None
 
     if profile.latest_analysis_job_id:
         job_row = await db.execute(
@@ -155,6 +156,12 @@ async def get_vocal_profile(
                 "comfort": raw_range.get("comfort"),
             }
 
+            # 설명 문장 — {name} → 유저 닉네임으로 치환
+            raw_desc = rd.get("description_templates") or {}
+            if raw_desc:
+                name = current_user.nickname
+                descriptions = {k: v.replace("{name}", name) for k, v in raw_desc.items()}
+
     return VocalProfileResponse(
         user_id=current_user.id,
         has_profile=True,
@@ -166,6 +173,7 @@ async def get_vocal_profile(
         genreFit=genre_fit,
         timbre=timbre,
         range=range_info,
+        descriptions=descriptions,
     )
 
 

--- a/backend/app/schemas/analysis.py
+++ b/backend/app/schemas/analysis.py
@@ -52,4 +52,8 @@ class VocalProfileResponse(BaseModel):
     # data: [{note: "C#2", score: 0}, ...]  /  comfort: {from: "G4", to: "C#5"}
     range: Optional[Dict[str, Any]] = None
 
+    # 유저 이름이 치환된 설명 문장
+    # {timbre, genre_fit, vocal_range, vocal_traits}
+    descriptions: Optional[Dict[str, str]] = None
+
     model_config = {"from_attributes": True}


### PR DESCRIPTION
## 📌 Related Issue

- Closes #247 


## 📤 Tasks

- [x] `VocalProfileResponse`에 `descriptions` 필드 추가
- [x] `result_data`에서 `description_templates` 추출
- [x] 템플릿 문장 내 `{name}`을 현재 유저 닉네임으로 치환
- [x] 보컬 프로필 조회 응답에 설명 문구 포함
- [x] `analysis` 라우터 import 테스트 확인

<br/>

## 📸 Screenshot

- 별도 화면 변경 없음
- API 응답에 `descriptions` 필드 추가

예시 응답:

```json
{
  "descriptions": {
    "timbre": "...김민주님의 특히 따뜻함과 명료함 성향이...",
    "genre_fit": "...김민주님의 보컬이 각 장르의...",
    "vocal_range": "...김민주님이 편안하고 안정적으로...",
    "vocal_traits": "...김민주님의 특히 음정 안정성과..."
  }
}
````

<br/>

## 💌 To Reviewer

보컬 프로필 조회 API 응답에 사용자 맞춤 설명 문구를 추가했습니다.

기존 응답 구조는 유지하면서 `descriptions` 필드만 추가했으며,
`description_templates` 안의 `{name}` 값이 현재 로그인 유저의 닉네임으로 정상 치환되는지 확인 부탁드립니다.

또한 `description_templates`가 없는 경우에도 기존 응답 흐름에 영향이 없는지 함께 확인 부탁드립니다.

<br/>